### PR TITLE
Refactored the KafkaSdkConversions to use a type class pattern

### DIFF
--- a/src/main/scala/org/novelfs/streaming/kafka/KafkaSdkConversions.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/KafkaSdkConversions.scala
@@ -93,6 +93,4 @@ trait ToSdkConversions {
   }
 }
 
-object KafkaSdkConversions extends FromSdkConversions with ToSdkConversions {
-
-}
+object KafkaSdkConversions extends FromSdkConversions with ToSdkConversions

--- a/src/main/scala/org/novelfs/streaming/kafka/KafkaSdkConversions.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/KafkaSdkConversions.scala
@@ -2,43 +2,97 @@ package org.novelfs.streaming.kafka
 
 import java.util
 
-import org.apache.kafka.clients.consumer.{ConsumerRecord, OffsetAndMetadata}
+import org.apache.kafka.clients.consumer.{ConsumerRecord, ConsumerRecords, OffsetAndMetadata}
 import org.apache.kafka.common
 
 import scala.collection.JavaConverters._
 
-object KafkaSdkConversions {
-
-  def toKafkaOffsetMap(offsetMap : Map[TopicPartition, OffsetMetadata]): util.Map[common.TopicPartition, OffsetAndMetadata] =
-    offsetMap.map{case (tp, om) => TopicPartition.toKafkaTopicPartition(tp) -> OffsetMetadata.toKafkaOffsetMetadata(om) }.asJava
-
-  def fromKafkaOffsetMap(kafkaOffsetMap : util.Map[common.TopicPartition, OffsetAndMetadata]) : Map[TopicPartition, OffsetMetadata] =
-    kafkaOffsetMap.asScala
-      .map{case (topicPartition, offsetMetadata) => TopicPartition(topicPartition.topic(), topicPartition.partition()) -> OffsetMetadata(offsetMetadata.offset())}
-      .toMap
-
+trait FromKafkaSdk[A] {
   /**
-    * Converts the kafka model of Consumer Records to strongly-typed Kafka records
+    * Convert from a Kafka Sdk representation of the type into the strongly typed version from this library
     */
-  def fromConsumerRecord[K, V](consumerRecord: ConsumerRecord[K, V]): KafkaRecord[K, V] = {
-    KafkaRecord(
-      topicPartition = TopicPartition(consumerRecord.topic(), consumerRecord.partition()),
-      offset = consumerRecord.offset(),
-      key = consumerRecord.key(),
-      value = consumerRecord.value(),
-      timestamp = consumerRecord.timestamp match {
-        case ConsumerRecord.NO_TIMESTAMP => None
-        case x => Some(x)
-      },
-      serializedKeySize = consumerRecord.serializedKeySize match {
-        case ConsumerRecord.NULL_SIZE => None
-        case x => Some(x)
-      },
-      serializedValueSize = consumerRecord.serializedValueSize match {
-        case ConsumerRecord.NULL_SIZE => None
-        case x => Some(x)
-      },
-      headers = consumerRecord.headers().toArray.map(h => KafkaHeader(h.key, h.value)).toList
-    )
+  def fromKafkaSdk : A
+}
+
+trait ToKafkaSdk[A] {
+  /**
+    * Convert from this library's representation of a type into the Kafka Sdk representation
+    */
+  def toKafkaSdk : A
+}
+
+trait FromSdkConversions {
+
+  implicit class TopicPartitionFromKafkaSdk(tp : common.TopicPartition) extends FromKafkaSdk[TopicPartition] {
+    override def fromKafkaSdk: TopicPartition = TopicPartition(tp.topic, tp.partition)
   }
+
+  implicit class OffsetMetadataFromKafkaSdk(om : org.apache.kafka.clients.consumer.OffsetAndMetadata) extends FromKafkaSdk[OffsetMetadata] {
+    override def fromKafkaSdk: OffsetMetadata = OffsetMetadata(om.offset)
+  }
+
+  implicit class ConsumerRecordFromKafkaSdk[K, V](consumerRecord: ConsumerRecord[K, V]) extends FromKafkaSdk[KafkaRecord[K, V]] {
+    def fromKafkaSdk: KafkaRecord[K, V] =
+      KafkaRecord(
+        topicPartition = TopicPartition(consumerRecord.topic(), consumerRecord.partition()),
+        offset = consumerRecord.offset(),
+        key = consumerRecord.key(),
+        value = consumerRecord.value(),
+        timestamp = consumerRecord.timestamp match {
+          case ConsumerRecord.NO_TIMESTAMP => None
+          case x => Some(x)
+        },
+        serializedKeySize = consumerRecord.serializedKeySize match {
+          case ConsumerRecord.NULL_SIZE => None
+          case x => Some(x)
+        },
+        serializedValueSize = consumerRecord.serializedValueSize match {
+          case ConsumerRecord.NULL_SIZE => None
+          case x => Some(x)
+        },
+        headers = consumerRecord.headers().toArray.map(h => KafkaHeader(h.key, h.value)).toList
+      )
+  }
+
+  implicit class MapFromKafkaSdkConversions[K1, V1, K2, V2](m : util.Map[K1, V1])(implicit ev : K1 => FromKafkaSdk[K2], ev2 : V1 => FromKafkaSdk[V2]) extends FromKafkaSdk[Map[K2, V2]] {
+    def fromKafkaSdk: Map[K2, V2] =
+      m.asScala
+        .map{case (o1, o2) => o1.fromKafkaSdk -> o2.fromKafkaSdk}
+        .toMap
+  }
+
+  implicit class SetFromKafkaSdkConversions[T1, T2](m : util.Set[T1])(implicit ev : T1 => FromKafkaSdk[T2]) extends FromKafkaSdk[Set[T2]] {
+    def fromKafkaSdk: Set[T2] =
+      m.asScala
+        .map(_.fromKafkaSdk)
+        .toSet
+  }
+
+  implicit class ConsumerRecordsFromKafkaSdkConversions[K, V](consumerRecords : ConsumerRecords[K, V]) extends FromKafkaSdk[Vector[KafkaRecord[K, V]]] {
+    def fromKafkaSdk: Vector[KafkaRecord[K, V]] =
+      consumerRecords.asScala
+        .map(_.fromKafkaSdk)
+        .toVector
+  }
+}
+
+trait ToSdkConversions {
+
+  implicit class TopicPartitionToKafkaSdk(tp : TopicPartition) extends ToKafkaSdk[common.TopicPartition] {
+    def toKafkaSdk: common.TopicPartition = new common.TopicPartition(tp.topic, tp.partition)
+  }
+
+  implicit class OffsetMetadataToKafkaSdk(om : OffsetMetadata) extends ToKafkaSdk[org.apache.kafka.clients.consumer.OffsetAndMetadata] {
+    override def toKafkaSdk: OffsetAndMetadata = new org.apache.kafka.clients.consumer.OffsetAndMetadata(om.offset)
+  }
+
+  implicit class MapToKafkaSdkConversions[K1, V1, K2, V2](m : Map[K1, V1])(implicit ev : K1 => ToKafkaSdk[K2], ev2 : V1 => ToKafkaSdk[V2]) extends ToKafkaSdk[util.Map[K2, V2]] {
+    def toKafkaSdk: util.Map[K2, V2] =
+      m.map{case (o1, o2) => o1.toKafkaSdk -> o2.toKafkaSdk}
+        .asJava
+  }
+}
+
+object KafkaSdkConversions extends FromSdkConversions with ToSdkConversions {
+
 }

--- a/src/main/scala/org/novelfs/streaming/kafka/OffsetMetadata.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/OffsetMetadata.scala
@@ -1,9 +1,3 @@
 package org.novelfs.streaming.kafka
 
 case class OffsetMetadata(offset : Long)
-
-object OffsetMetadata {
-  def toKafkaOffsetMetadata(om : OffsetMetadata): org.apache.kafka.clients.consumer.OffsetAndMetadata = {
-    new org.apache.kafka.clients.consumer.OffsetAndMetadata(om.offset)
-  }
-}

--- a/src/main/scala/org/novelfs/streaming/kafka/TopicPartition.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/TopicPartition.scala
@@ -1,11 +1,3 @@
 package org.novelfs.streaming.kafka
 
-import org.apache.kafka.common
-
 case class TopicPartition(topic : String, partition : Int)
-
-object TopicPartition {
-  def toKafkaTopicPartition(tp : TopicPartition): common.TopicPartition = {
-    new org.apache.kafka.common.TopicPartition(tp.topic, tp.partition)
-  }
-}

--- a/src/test/scala/org/novelfs/streaming/kafka/KafkaConsumerSpec.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/KafkaConsumerSpec.scala
@@ -10,6 +10,7 @@ import scala.concurrent.duration._
 import collection.JavaConverters._
 import fs2._
 import org.apache.kafka.common.serialization.Deserializer
+import KafkaSdkConversions._
 
 class KafkaConsumerSpec extends FlatSpec with Matchers with MockFactory with GeneratorDrivenPropertyChecks with DomainArbitraries {
 
@@ -30,7 +31,7 @@ class KafkaConsumerSpec extends FlatSpec with Matchers with MockFactory with Gen
 
   "commit offset map" should "call consumer.commitAsync with the supplied OffsetMap" in {
     forAll { (offsetMap : Map[TopicPartition, OffsetMetadata]) =>
-      val javaMap = offsetMap.map{case (tp, om) => TopicPartition.toKafkaTopicPartition(tp) -> OffsetMetadata.toKafkaOffsetMetadata(om) }.asJava
+      val javaMap = offsetMap.toKafkaSdk
 
       (rawKafkaConsumer.commitAsync(_ : java.util.Map[org.apache.kafka.common.TopicPartition,  org.apache.kafka.clients.consumer.OffsetAndMetadata], _ : OffsetCommitCallback))
           .expects (javaMap, *) onCall { (_, callback) => callback.onComplete(javaMap, null) } once()

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.5"
+version in ThisBuild := "0.0.6"


### PR DESCRIPTION
Refactored the KafkaSdkConversions to use a type class pattern
- Can now convert from the Kafka Sdk representation with `.fromKafkaSdk`
- Can now convert to the Kafka Sdk representation with `.toKafkaSdk`
- Some collection conversions have also been added
- Conversions available by adding `import org.novelfs.streaming.kafka.KafkaSdkConversions._`