### PR TITLE
Offset and error handling refactoring

### DIFF
--- a/src/main/scala/org/novelfs/streaming/kafka/KafkaConsumer.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/KafkaConsumer.scala
@@ -49,7 +49,7 @@ object KafkaConsumer {
     _.noneTerminate
       .zipWithPrevious
       .observe1 {
-        case (Some(Some(valueAndOffsetMap)), None) => commitOffsetMap(consumer)(valueAndOffsetMap._2)
+        case (Some(Some((_, offsetMap))), None) => commitOffsetMap(consumer)(offsetMap)
         case _ => Effect[F].unit
       }
       .map {case (_, valueAndOffsetMap) => valueAndOffsetMap}

--- a/src/main/scala/org/novelfs/streaming/kafka/KafkaConsumer.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/KafkaConsumer.scala
@@ -13,6 +13,8 @@ import scala.concurrent.duration.FiniteDuration
 import scala.collection.JavaConverters._
 import KafkaSdkConversions._
 
+final case class KafkaConsumer[K, V](kafkaConsumer : ApacheKafkaConsumer[K, V])
+
 object KafkaConsumer {
 
   private val log = LoggerFactory.getLogger(KafkaConsumer.getClass)
@@ -22,9 +24,9 @@ object KafkaConsumer {
   /**
     * An effect to commit supplied map of offset metadata for each topic/partition pair
     */
-  def commitOffsetMap[F[_] : Effect, K, V](consumer : ApacheKafkaConsumer[K, V])(offsetMap : Map[TopicPartition, OffsetMetadata]): F[Unit] =
+  def commitOffsetMap[F[_] : Effect, K, V](consumer : KafkaConsumer[K, V])(offsetMap : Map[TopicPartition, OffsetMetadata]): F[Unit] =
     Async[F].async { (cb: Either[Throwable, Unit] => Unit) =>
-      consumer.commitAsync(offsetMap.toKafkaSdk, (_: java.util.Map[_, _], exception: Exception) => Option(exception) match {
+      consumer.kafkaConsumer.commitAsync(offsetMap.toKafkaSdk, (_: java.util.Map[_, _], exception: Exception) => Option(exception) match {
         case None =>
           log.debug(s"Offset committed: $offsetMap")
           cb(Right(()))
@@ -41,56 +43,67 @@ object KafkaConsumer {
     _.zipWithScan(Map.empty[TopicPartition, OffsetMetadata])((map, record) => map + (record.topicPartition -> OffsetMetadata(record.offset)))
 
   /**
+    * A pipe that commits the final available offset data for each topic/partition pair for the supplied input stream of Consumer Records
+    */
+  def commitFinalOffsets[F[_] : Effect, K, V](consumer : KafkaConsumer[K, V]) : Pipe[F, (KafkaRecord[K, V], Map[TopicPartition, OffsetMetadata]), (KafkaRecord[K, V], Map[TopicPartition, OffsetMetadata])] =
+    _.noneTerminate
+      .zipWithPrevious
+      .observe1 {
+        case (Some(Some(valueAndOffsetMap)), None) => commitOffsetMap(consumer)(valueAndOffsetMap._2)
+        case _ => Effect[F].unit
+      }
+      .map {case (_, valueAndOffsetMap) => valueAndOffsetMap}
+      .unNoneTerminate
+
+  /**
     * A convenience pipe that accumulates offset metadata based on the supplied commitSettings and commits them to Kafka at some defined frequency
     */
-  def commitOffsets[F[_] : Effect, K, V]
-    (consumer : ApacheKafkaConsumer[Array[Byte], Array[Byte]])(autoCommitSettings: KafkaOffsetCommitSettings.AutoCommit)
-    (implicit ex : ExecutionContext): Pipe[F, KafkaRecord[K,V], KafkaRecord[K,V]] = (s : Stream[F, KafkaRecord[K, V]]) =>
-      s.through(accumulateOffsetMetadata)
+  def commitOffsets[F[_] : Effect, K, V](consumer : KafkaConsumer[K, V])(autoCommitSettings: KafkaOffsetCommitSettings.AutoCommit)(implicit ex : ExecutionContext): Pipe[F, KafkaRecord[K,V], KafkaRecord[K,V]] =
+      _.through(accumulateOffsetMetadata)
         .observeAsync(autoCommitSettings.maxAsyncCommits)(s =>
-          s.takeElementsEvery(autoCommitSettings.timeBetweenCommits)
-            .evalMap{case (_, offsetMap) => commitOffsetMap(consumer)(offsetMap)})
+            s.through(commitFinalOffsets(consumer))
+              .takeElementsEvery(autoCommitSettings.timeBetweenCommits)
+              .evalMap {case (_, offsetMap) => commitOffsetMap(consumer)(offsetMap)})
         .map{case (r,_) => r}
-
 
   /**
     * An effect that generates a subscription to some Kafka topics/paritions using the supplied kafka config
     */
-  def subscribeToConsumer[F[_] : Async, K, V](config : KafkaConsumerConfig[K, V]): F[ApacheKafkaConsumer[Array[Byte], Array[Byte]]] = {
+  def subscribeToConsumer[F[_] : Async, K, V](config : KafkaConsumerConfig[K, V]): F[KafkaConsumer[Array[Byte], Array[Byte]]] = {
     val consumer = new ConcreteApacheKafkaConsumer(KafkaConsumerConfig.generateProperties(config), new ByteArrayDeserializer(), new ByteArrayDeserializer())
-    Async[F].delay (consumer.subscribe(config.topics.asJava)) *> Async[F].point(consumer)
+    Async[F].delay (consumer.subscribe(config.topics.asJava)) *> Async[F].point(KafkaConsumer(consumer))
   }
 
   /**
     * An effect that disposes of some supplied kafka consumer
     */
-  def cleanupConsumer[F[_] : Async, K, V](consumer : ApacheKafkaConsumer[K,V]): F[Unit] = Async[F].delay(consumer.close())
+  def cleanupConsumer[F[_] : Async, K, V](consumer : KafkaConsumer[K, V]): F[Unit] = Async[F].delay(consumer.kafkaConsumer.close())
 
   /**
     * An effect that polls kafka (once) with a supplied timeout
     */
-  def pollKafka[F[_] : Async, K, V](consumer : ApacheKafkaConsumer[K, V])(pollTimeout : FiniteDuration): F[Vector[KafkaRecord[K, V]]] =
-    Async[F].delay(consumer.poll(pollTimeout.toMillis).fromKafkaSdk)
+  def pollKafka[F[_] : Async, K, V](consumer : KafkaConsumer[K, V])(pollTimeout : FiniteDuration): F[Vector[KafkaRecord[K, V]]] =
+    Async[F].delay(consumer.kafkaConsumer.poll(pollTimeout.toMillis).fromKafkaSdk)
 
   /**
     * A pipe that deserialises an array of bytes using supplied key and value deserialisers
     */
-  def deserializer[F[_] : Async, K, V](keyDeserializer: Deserializer[K], valueDeserializer : Deserializer[V]) : Pipe[F, KafkaRecord[Array[Byte], Array[Byte]], KafkaRecord[K, V]] =
+  def deserializer[F[_] : Async, K, V](keyDeserializer: Deserializer[K], valueDeserializer : Deserializer[V]) : Pipe[F, KafkaRecord[Array[Byte], Array[Byte]], Either[Throwable, KafkaRecord[K, V]]] =
     _.evalMap(record =>
       Async[F].delay {
         val key = keyDeserializer.deserialize(record.topicPartition.topic, record.key)
         val value = valueDeserializer.deserialize(record.topicPartition.topic, record.value)
         record.copy(key = key, value = value)
-      }
+      }.attempt
     )
 
-  def topicPartitionAssignments[F[_] : Async, K, V](consumer : ApacheKafkaConsumer[K, V]): F[Set[TopicPartition]] =
-    Async[F].delay { consumer.assignment().fromKafkaSdk }
+  def topicPartitionAssignments[F[_] : Async, K, V](consumer : KafkaConsumer[K, V]): F[Set[TopicPartition]] =
+    Async[F].delay { consumer.kafkaConsumer.assignment().fromKafkaSdk }
 
   /**
     * Creates a streaming subscription using the supplied kafka configuration
     */
-  def apply[F[_] : Effect, K, V](config : KafkaConsumerConfig[K, V])(implicit ex : ExecutionContext): Stream[F, KafkaRecord[K, V]] =
+  def apply[F[_] : Effect, K, V](config : KafkaConsumerConfig[K, V])(implicit ex : ExecutionContext): Stream[F, Either[Throwable, KafkaRecord[K, V]]] =
     Stream.bracket(subscribeToConsumer(config))(consumer =>
       for {
         records <- Stream.repeatEval(pollKafka(consumer)(config.pollTimeout))

--- a/src/main/scala/org/novelfs/streaming/kafka/ops/package.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/ops/package.scala
@@ -1,7 +1,6 @@
 package org.novelfs.streaming.kafka
 
 import fs2._
-import cats.implicits._
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -11,12 +10,5 @@ package object ops {
       s.tail.zip(Stream.every(d))
         .filterWithPrevious{case ((_,t1), (_, t2)) => t1 != t2}
         .map{case (x,_) => x}
-
-
-    def suppressErrorWith(f : PartialFunction[Throwable, F[Unit]]): Stream[F, O] =
-      s.handleErrorWith(t => f.lift(t) match {
-        case Some(act) => Stream.eval(act).flatMap(_ => Stream.empty)
-        case None => Stream.raiseError(t)
-      })
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.6"
+version in ThisBuild := "0.1.1"


### PR DESCRIPTION
- The final offsets will now be committed as part of the default configuration when auto-commit is enabled.
   - Added a pipe to support manual committing of the final offsets
- Reified the potential error as an `Either` in the `deserializer` pipe so that deserialisation problems can be handled.
- The `Stream` returned from `KafkaConsumer.apply` now likewise returns `Either` to cover potential deserialisation errors.
- The Java SDK KafkaConsumer is now wrapped in a `KafkaConsumer` case class to simplify the required imports and avoid exposing a mutable API.