### PR TITLE
Add kafka producer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ libraryDependencies ++= Seq(
   , "org.apache.kafka" %% "kafka" % "1.0.0"
   , "co.fs2" %% "fs2-core" % "0.10.1"
   , "co.fs2" %% "fs2-io" % "0.10.1"
+  , "net.manub" %% "scalatest-embedded-kafka" % "1.1.0" % Test
 )
 
 addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.4")

--- a/src/main/scala/org/novelfs/streaming/kafka/KafkaHeader.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/KafkaHeader.scala
@@ -1,0 +1,7 @@
+package org.novelfs.streaming.kafka
+
+/**
+  * @param key The key of the header
+  * @param value The value of the header
+  */
+final case class KafkaHeader(key : String, value : Array[Byte])

--- a/src/main/scala/org/novelfs/streaming/kafka/KafkaSdkConversions.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/KafkaSdkConversions.scala
@@ -2,8 +2,13 @@ package org.novelfs.streaming.kafka
 
 import java.util
 
-import org.apache.kafka.clients.consumer.{ConsumerRecord, ConsumerRecords, OffsetAndMetadata}
+import org.apache.kafka.clients.consumer.{OffsetAndMetadata, ConsumerRecord => ApacheConsumerRecord, ConsumerRecords => ApacheConsumerRecords}
+import org.apache.kafka.clients.producer.{ProducerRecord => ApacheProducerRecord}
 import org.apache.kafka.common
+import org.apache.kafka.common.header.Header
+import org.apache.kafka.common.header.internals.{RecordHeader, RecordHeaders}
+import org.novelfs.streaming.kafka.consumer.{ConsumerRecord, OffsetMetadata}
+import org.novelfs.streaming.kafka.producer.ProducerRecord
 
 import scala.collection.JavaConverters._
 
@@ -31,45 +36,45 @@ trait FromSdkConversions {
     override def fromKafkaSdk: OffsetMetadata = OffsetMetadata(om.offset)
   }
 
-  implicit class ConsumerRecordFromKafkaSdk[K, V](consumerRecord: ConsumerRecord[K, V]) extends FromKafkaSdk[KafkaRecord[K, V]] {
-    def fromKafkaSdk: KafkaRecord[K, V] =
-      KafkaRecord(
+  implicit class ConsumerRecordFromKafkaSdk[K, V](consumerRecord: ApacheConsumerRecord[K, V]) extends FromKafkaSdk[ConsumerRecord[K, V]] {
+    def fromKafkaSdk: ConsumerRecord[K, V] =
+      ConsumerRecord(
         topicPartition = TopicPartition(consumerRecord.topic(), consumerRecord.partition()),
         offset = consumerRecord.offset(),
         key = consumerRecord.key(),
         value = consumerRecord.value(),
         timestamp = consumerRecord.timestamp match {
-          case ConsumerRecord.NO_TIMESTAMP => None
+          case ApacheConsumerRecord.NO_TIMESTAMP => None
           case x => Some(x)
         },
         serializedKeySize = consumerRecord.serializedKeySize match {
-          case ConsumerRecord.NULL_SIZE => None
+          case ApacheConsumerRecord.NULL_SIZE => None
           case x => Some(x)
         },
         serializedValueSize = consumerRecord.serializedValueSize match {
-          case ConsumerRecord.NULL_SIZE => None
+          case ApacheConsumerRecord.NULL_SIZE => None
           case x => Some(x)
         },
         headers = consumerRecord.headers().toArray.map(h => KafkaHeader(h.key, h.value)).toList
       )
   }
 
-  implicit class MapFromKafkaSdkConversions[K1, V1, K2, V2](m : util.Map[K1, V1])(implicit ev : K1 => FromKafkaSdk[K2], ev2 : V1 => FromKafkaSdk[V2]) extends FromKafkaSdk[Map[K2, V2]] {
+  implicit class MapFromKafkaSdk[K1, V1, K2, V2](m : util.Map[K1, V1])(implicit ev : K1 => FromKafkaSdk[K2], ev2 : V1 => FromKafkaSdk[V2]) extends FromKafkaSdk[Map[K2, V2]] {
     def fromKafkaSdk: Map[K2, V2] =
       m.asScala
         .map{case (o1, o2) => o1.fromKafkaSdk -> o2.fromKafkaSdk}
         .toMap
   }
 
-  implicit class SetFromKafkaSdkConversions[T1, T2](m : util.Set[T1])(implicit ev : T1 => FromKafkaSdk[T2]) extends FromKafkaSdk[Set[T2]] {
+  implicit class SetFromKafkaSdk[T1, T2](m : util.Set[T1])(implicit ev : T1 => FromKafkaSdk[T2]) extends FromKafkaSdk[Set[T2]] {
     def fromKafkaSdk: Set[T2] =
       m.asScala
         .map(_.fromKafkaSdk)
         .toSet
   }
 
-  implicit class ConsumerRecordsFromKafkaSdkConversions[K, V](consumerRecords : ConsumerRecords[K, V]) extends FromKafkaSdk[Vector[KafkaRecord[K, V]]] {
-    def fromKafkaSdk: Vector[KafkaRecord[K, V]] =
+  implicit class ConsumerRecordsFromKafkaSdk[K, V](consumerRecords : ApacheConsumerRecords[K, V]) extends FromKafkaSdk[Vector[ConsumerRecord[K, V]]] {
+    def fromKafkaSdk: Vector[ConsumerRecord[K, V]] =
       consumerRecords.asScala
         .map(_.fromKafkaSdk)
         .toVector
@@ -86,10 +91,24 @@ trait ToSdkConversions {
     override def toKafkaSdk: OffsetAndMetadata = new org.apache.kafka.clients.consumer.OffsetAndMetadata(om.offset)
   }
 
-  implicit class MapToKafkaSdkConversions[K1, V1, K2, V2](m : Map[K1, V1])(implicit ev : K1 => ToKafkaSdk[K2], ev2 : V1 => ToKafkaSdk[V2]) extends ToKafkaSdk[util.Map[K2, V2]] {
+  implicit class MapToKafkaSdk[K1, V1, K2, V2](m : Map[K1, V1])(implicit ev : K1 => ToKafkaSdk[K2], ev2 : V1 => ToKafkaSdk[V2]) extends ToKafkaSdk[util.Map[K2, V2]] {
     def toKafkaSdk: util.Map[K2, V2] =
       m.map{case (o1, o2) => o1.toKafkaSdk -> o2.toKafkaSdk}
         .asJava
+  }
+
+  implicit class ProducerRecordToKafkaSdk[K, V](kafkaRecord : ProducerRecord[K, V]) extends ToKafkaSdk[ApacheProducerRecord[K, V]] {
+    def toKafkaSdk: ApacheProducerRecord[K, V] = {
+      val headers: Array[Header] = kafkaRecord.headers.toArray.map(h => new RecordHeader(h.key, h.value) )
+      new ApacheProducerRecord[K, V](
+        kafkaRecord.topic,
+        kafkaRecord.partition.map(new java.lang.Integer(_)).orNull,
+        kafkaRecord.timestamp.map(new java.lang.Long(_)).orNull,
+        kafkaRecord.key,
+        kafkaRecord.value,
+        new RecordHeaders(headers)
+      )
+    }
   }
 }
 

--- a/src/main/scala/org/novelfs/streaming/kafka/KafkaSecuritySettings.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/KafkaSecuritySettings.scala
@@ -1,5 +1,10 @@
 package org.novelfs.streaming.kafka
 
+import java.util.Properties
+
+import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.common.config.SslConfigs
+
 /**
   * @param trustStoreLocation The location of the trust store file
   * @param trustStorePassword The password for the trust store file
@@ -19,4 +24,18 @@ object KafkaSecuritySettings {
   final case class EncryptedNotAuthenticated(encryptionSettings: KafkaEncryptionSettings) extends KafkaSecuritySettings
   final case class AuthenticatedNotEncrypted(authSettings: KafkaAuthenticationSettings) extends KafkaSecuritySettings
   final case class EncryptedAndAuthenticated(encryptionSettings: KafkaEncryptionSettings, authSettings: KafkaAuthenticationSettings) extends KafkaSecuritySettings
+
+  def addEncryptionProps(props: Properties)(encryptionSettings: KafkaEncryptionSettings): Properties = {
+    props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL")
+    props.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, encryptionSettings.trustStoreLocation)
+    props.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, encryptionSettings.trustStorePassword)
+    props
+  }
+
+  def addAuthenticationProps(props: Properties)(authSettings: KafkaAuthenticationSettings): Properties = {
+    props.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, authSettings.keyStoreLocation)
+    props.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, authSettings.keyStorePassword)
+    props.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, authSettings.keyPassword)
+    props
+  }
 }

--- a/src/main/scala/org/novelfs/streaming/kafka/OffsetMetadata.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/OffsetMetadata.scala
@@ -1,3 +1,0 @@
-package org.novelfs.streaming.kafka
-
-case class OffsetMetadata(offset : Long)

--- a/src/main/scala/org/novelfs/streaming/kafka/consumer/ConsumerRecord.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/consumer/ConsumerRecord.scala
@@ -1,10 +1,6 @@
-package org.novelfs.streaming.kafka
+package org.novelfs.streaming.kafka.consumer
 
-/**
-  * @param key The key of the header
-  * @param value The value of the header
-  */
-final case class KafkaHeader(key : String, value : Array[Byte])
+import org.novelfs.streaming.kafka.{KafkaHeader, TopicPartition}
 
 /**
   * @param topicPartition The topic and partition this record was received from
@@ -16,7 +12,7 @@ final case class KafkaHeader(key : String, value : Array[Byte])
   * @param serializedValueSize The length of the serialised value, if it exists
   * @param headers The headers associated with the record
   */
-final case class KafkaRecord[K, V] (
+final case class ConsumerRecord[K, V](
     topicPartition : TopicPartition,
     offset : Long,
     key : K,
@@ -27,7 +23,7 @@ final case class KafkaRecord[K, V] (
     headers : List[KafkaHeader]
     )
 
-object KafkaRecord {
-  def apply[K, V](topicPartition: TopicPartition, offset: Long, key: K, value: V): KafkaRecord[K, V] =
-    new KafkaRecord(topicPartition, offset, key, value, None, None, None, List.empty)
+object ConsumerRecord {
+  def apply[K, V](topicPartition: TopicPartition, offset: Long, key: K, value: V): ConsumerRecord[K, V] =
+    new ConsumerRecord(topicPartition, offset, key, value, None, None, None, List.empty)
 }

--- a/src/main/scala/org/novelfs/streaming/kafka/consumer/KafkaConsumer.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/consumer/KafkaConsumer.scala
@@ -99,6 +99,9 @@ object KafkaConsumer {
       }.attempt
     )
 
+  /**
+    * An effect to return the set of topic and partition assignments attached to the supplied consumer
+    */
   def topicPartitionAssignments[F[_] : Async, K, V](consumer : KafkaConsumer[K, V]): F[Set[TopicPartition]] =
     Async[F].delay { consumer.kafkaConsumer.assignment().fromKafkaSdk }
 

--- a/src/main/scala/org/novelfs/streaming/kafka/consumer/KafkaConsumerConfig.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/consumer/KafkaConsumerConfig.scala
@@ -1,10 +1,11 @@
-package org.novelfs.streaming.kafka
+package org.novelfs.streaming.kafka.consumer
 
 import java.util.Properties
+
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.serialization.Deserializer
-import org.apache.kafka.common.config.SslConfigs
-import org.apache.kafka.clients.CommonClientConfigs
+import org.novelfs.streaming.kafka._
+
 import scala.concurrent.duration._
 
 case class KafkaConsumerConfig[K, V](
@@ -53,27 +54,13 @@ object KafkaConsumerConfig {
     props.put(ConsumerConfig.GROUP_ID_CONFIG,           kafkaConsumerConfig.groupId)
     kafkaConsumerConfig.security match {
       case KafkaSecuritySettings.EncryptedAndAuthenticated(encryptionSettings, authSettings) =>
-        addEncryptionProps(addAuthenticationProps(props)(authSettings))(encryptionSettings)
+        KafkaSecuritySettings.addEncryptionProps(KafkaSecuritySettings.addAuthenticationProps(props)(authSettings))(encryptionSettings)
       case KafkaSecuritySettings.EncryptedNotAuthenticated(encryptionSettings) =>
-        addEncryptionProps(props)(encryptionSettings)
+        KafkaSecuritySettings.addEncryptionProps(props)(encryptionSettings)
       case KafkaSecuritySettings.AuthenticatedNotEncrypted(authSettings) =>
-        addAuthenticationProps(props)(authSettings)
+        KafkaSecuritySettings.addAuthenticationProps(props)(authSettings)
       case KafkaSecuritySettings.NoSecurity =>
         props
     }
-  }
-
-  private def addEncryptionProps(props: Properties)(encryptionSettings: KafkaEncryptionSettings) = {
-    props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SSL")
-    props.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, encryptionSettings.trustStoreLocation)
-    props.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, encryptionSettings.trustStorePassword)
-    props
-  }
-
-  private def addAuthenticationProps(props: Properties)(authSettings: KafkaAuthenticationSettings) = {
-    props.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, authSettings.keyStoreLocation)
-    props.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, authSettings.keyStorePassword)
-    props.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, authSettings.keyPassword)
-    props
   }
 }

--- a/src/main/scala/org/novelfs/streaming/kafka/consumer/KafkaOffsetCommitSettings.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/consumer/KafkaOffsetCommitSettings.scala
@@ -1,4 +1,4 @@
-package org.novelfs.streaming.kafka
+package org.novelfs.streaming.kafka.consumer
 
 import scala.concurrent.duration.FiniteDuration
 

--- a/src/main/scala/org/novelfs/streaming/kafka/consumer/OffsetMetadata.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/consumer/OffsetMetadata.scala
@@ -1,0 +1,3 @@
+package org.novelfs.streaming.kafka.consumer
+
+case class OffsetMetadata(offset : Long)

--- a/src/main/scala/org/novelfs/streaming/kafka/ops/package.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/ops/package.scala
@@ -1,14 +1,26 @@
 package org.novelfs.streaming.kafka
 
+import cats.effect.Effect
 import fs2._
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
 package object ops {
-  implicit class ExtraStreamOps[F[_], O](s : Stream[F, O]) {
-    def takeElementsEvery(d : FiniteDuration) =
-      s.tail.zip(Stream.every(d))
-        .filterWithPrevious{case ((_,t1), (_, t2)) => t1 != t2}
-        .map{case (x,_) => x}
+  implicit class ExtraStreamOps[F[_] : Effect, O](s : Stream[F, O]) {
+
+    def takeElementsEvery(d : FiniteDuration)(implicit ec : ExecutionContext) =
+      Scheduler[F](corePoolSize = 2).flatMap(scheduler =>
+        s.either(scheduler.awakeEvery(d))
+          .zipWithPrevious
+          .filter {
+            case  (Some(Right(_)), Left(_)) => true
+            case _ => false
+          }
+          .map{case (_, x) => x}
+          .collect{case Left(x) => x}
+      )
+
+
   }
 }

--- a/src/main/scala/org/novelfs/streaming/kafka/producer/KafkaProducer.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/producer/KafkaProducer.scala
@@ -1,0 +1,56 @@
+package org.novelfs.streaming.kafka.producer
+
+import cats.effect._
+import cats.implicits._
+import fs2._
+import org.apache.kafka.clients.producer.{KafkaProducer => ConcreteApacheKafkaProducer, Producer => ApacheKafkaProducer}
+import org.apache.kafka.common.serialization.{ByteArraySerializer, Serializer}
+import org.novelfs.streaming.kafka.KafkaSdkConversions
+//import org.slf4j.LoggerFactory
+import KafkaSdkConversions._
+
+final case class KafkaProducer[K, V] private (kafkaProducer : ApacheKafkaProducer[K, V])
+
+object KafkaProducer {
+  //private val log = LoggerFactory.getLogger(KafkaProducer.getClass)
+
+  /**
+    * A pipe that serialises records to bytes using supplied key and value serialisers
+    */
+  def serializer[F[_] : Async, K, V](keySerializer: Serializer[K], valueSerializer : Serializer[V]) : Pipe[F, ProducerRecord[K, V], Either[Throwable, ProducerRecord[Array[Byte], Array[Byte]]]] =
+    _.evalMap(record =>
+      Async[F].delay {
+        val key = keySerializer.serialize(record.topic, record.key)
+        val value = valueSerializer.serialize(record.topic, record.value)
+        record.copy(key = key, value = value)
+      }.attempt
+    )
+
+  def sendRecord[F[_] : Async, K, V](record: ProducerRecord[K, V])(producer: KafkaProducer[K, V]): F[Unit] =
+    Async[F].delay {
+      producer.kafkaProducer.send(record.toKafkaSdk)
+      ()
+    }
+
+  def createProducer[F[_] : Async, K, V](producerConfig : KafkaProducerConfig[K, V]): F[KafkaProducer[Array[Byte], Array[Byte]]] =
+    Async[F].delay {
+      val props = KafkaProducerConfig.generateProperties(producerConfig)
+      val producer = new ConcreteApacheKafkaProducer[Array[Byte], Array[Byte]](props, new ByteArraySerializer(), new ByteArraySerializer())
+      KafkaProducer(producer)
+    }
+
+  def cleanupProducer[F[_] : Async, K, V](producer : KafkaProducer[K, V]): F[Unit] =
+    Async[F].delay(producer.kafkaProducer.close())
+
+  def apply[F[_] : Async, K, V](producerConfig : KafkaProducerConfig[K, V]) : Pipe[F, ProducerRecord[K, V], Either[Throwable, Unit]] = s =>
+    Stream.bracket(createProducer(producerConfig))(producer => {
+      s.through(serializer(producerConfig.keySerializer, producerConfig.valueSerializer))
+        .observe1 {
+          case Right(r) => sendRecord(r)(producer)
+          case Left(_)  => Async[F].unit
+        }
+        .map(_.map(_ => ()))
+    }, cleanupProducer[F, Array[Byte], Array[Byte]])
+
+
+}

--- a/src/main/scala/org/novelfs/streaming/kafka/producer/KafkaProducerConfig.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/producer/KafkaProducerConfig.scala
@@ -1,0 +1,48 @@
+package org.novelfs.streaming.kafka.producer
+
+import java.util.Properties
+
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.serialization.Serializer
+import org.novelfs.streaming.kafka.KafkaSecuritySettings
+
+case class KafkaProducerConfig[K, V](
+    brokers              : List[String],
+    security             : KafkaSecuritySettings,
+    keySerializer        : Serializer[K],
+    valueSerializer      : Serializer[V]
+    )
+
+object KafkaProducerConfig {
+  def apply[K, V](
+               brokers              : List[String],
+               security             : KafkaSecuritySettings,
+               keySerializer        : Serializer[K],
+               valueSerializer      : Serializer[V]) : KafkaProducerConfig[K, V] =
+    KafkaProducerConfig(
+      brokers = brokers,
+      security = security,
+      keySerializer = keySerializer,
+      valueSerializer = valueSerializer
+    )
+
+  def generateProperties[K, V](kafkaProducerConfig: KafkaProducerConfig[K, V]): Properties = {
+    val props: Properties = new Properties()
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProducerConfig.brokers.mkString(","))
+    props.put(ProducerConfig.ACKS_CONFIG, "all")
+    props.put(ProducerConfig.RETRIES_CONFIG, new java.lang.Integer(0))
+    props.put(ProducerConfig.BATCH_SIZE_CONFIG, new java.lang.Integer(16384))
+    props.put(ProducerConfig.LINGER_MS_CONFIG, new java.lang.Integer(1))
+    props.put(ProducerConfig.BUFFER_MEMORY_CONFIG, new java.lang.Integer(33554432))
+    kafkaProducerConfig.security match {
+      case KafkaSecuritySettings.EncryptedAndAuthenticated(encryptionSettings, authSettings) =>
+        KafkaSecuritySettings.addEncryptionProps(KafkaSecuritySettings.addAuthenticationProps(props)(authSettings))(encryptionSettings)
+      case KafkaSecuritySettings.EncryptedNotAuthenticated(encryptionSettings) =>
+        KafkaSecuritySettings.addEncryptionProps(props)(encryptionSettings)
+      case KafkaSecuritySettings.AuthenticatedNotEncrypted(authSettings) =>
+        KafkaSecuritySettings.addAuthenticationProps(props)(authSettings)
+      case KafkaSecuritySettings.NoSecurity =>
+         props
+    }
+  }
+}

--- a/src/main/scala/org/novelfs/streaming/kafka/producer/KafkaProducerConfig.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/producer/KafkaProducerConfig.scala
@@ -19,7 +19,7 @@ object KafkaProducerConfig {
                security             : KafkaSecuritySettings,
                keySerializer        : Serializer[K],
                valueSerializer      : Serializer[V]) : KafkaProducerConfig[K, V] =
-    KafkaProducerConfig(
+    new KafkaProducerConfig(
       brokers = brokers,
       security = security,
       keySerializer = keySerializer,

--- a/src/main/scala/org/novelfs/streaming/kafka/producer/ProducerRecord.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/producer/ProducerRecord.scala
@@ -1,0 +1,25 @@
+package org.novelfs.streaming.kafka.producer
+
+import org.novelfs.streaming.kafka.{KafkaHeader}
+
+/**
+  * @param topic The topic this record will be sent to
+  * @param partition The partition this record will be sent to (if none, the partition will be assigned by kafka)
+  * @param key The key of the record
+  * @param value The value of the record
+  * @param timestamp The timestamp of the record (if none, the timestamp will be assigned by kafka)
+  * @param headers The headers associated with the record
+  */
+final case class ProducerRecord[K, V](
+   topic : String,
+   partition : Option[Int],
+   key : K,
+   value : V,
+   timestamp : Option[Long],
+   headers : List[KafkaHeader]
+  )
+
+object ProducerRecord {
+  def apply[K, V](topic : String, partition : Option[Int], key: K, value: V): ProducerRecord[K, V] =
+    new ProducerRecord(topic, partition, key, value, None, List.empty)
+}

--- a/src/test/scala/org/novelfs/streaming/kafka/DomainArbitraries.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/DomainArbitraries.scala
@@ -42,7 +42,7 @@ trait DomainArbitraries {
   implicit val byteArrayConsumerRecordsArb: Arbitrary[List[ConsumerRecord[Array[Byte], Array[Byte]]]] =
     Arbitrary(for{
       topicPartitionList <- topicPartitionListArb.arbitrary
-      tempRecords <- Gen.listOfN(1000, for {
+      tempRecords <- Gen.listOfN(100, for {
         tp <- Gen.oneOf(topicPartitionList)
         key <- Gen.listOfN(128, Arbitrary.arbByte.arbitrary)
         value <- Gen.listOfN(256, Arbitrary.arbByte.arbitrary)
@@ -51,12 +51,15 @@ trait DomainArbitraries {
         ConsumerRecord[Array[Byte], Array[Byte]](tp, i.toLong, key.toArray, value.toArray) }
     } yield records)
 
-  implicit val stringProducerRecord : Arbitrary[ProducerRecord[String, String]] =
+  implicit val stringProducerRecordArb : Arbitrary[ProducerRecord[String, String]] =
     Arbitrary(for {
       topic <- Gen.alphaStr
       key <- Gen.alphaStr
       value <- Gen.alphaStr
     } yield ProducerRecord(topic, None, key, value))
+
+  implicit val stringProducerRecordsArb : Arbitrary[List[ProducerRecord[String, String]]] =
+    Arbitrary(Gen.listOfN(100, stringProducerRecordArb.arbitrary))
 
   implicit val kafkaEncryptionSettingsArb: Arbitrary[KafkaEncryptionSettings] =
     Arbitrary(for {

--- a/src/test/scala/org/novelfs/streaming/kafka/DomainArbitraries.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/DomainArbitraries.scala
@@ -1,5 +1,6 @@
 package org.novelfs.streaming.kafka
 
+import org.novelfs.streaming.kafka.consumer.{ConsumerRecord, KafkaConsumerConfig, OffsetMetadata}
 import org.scalacheck.{Arbitrary, Gen}
 
 import scala.concurrent.duration._
@@ -25,7 +26,7 @@ trait DomainArbitraries {
   implicit val topicPartitionListArb: Arbitrary[List[TopicPartition]] =
     Arbitrary(Gen.listOfN(5, topicPartitionArb.arbitrary))
 
-  implicit val stringConsumerRecordsArb: Arbitrary[List[KafkaRecord[String, String]]] =
+  implicit val stringConsumerRecordsArb: Arbitrary[List[ConsumerRecord[String, String]]] =
     Arbitrary(for{
       topicPartitionList <- topicPartitionListArb.arbitrary
       tempRecords <- Gen.listOfN(1000, for {
@@ -34,10 +35,10 @@ trait DomainArbitraries {
         value <- Gen.alphaStr
       } yield (tp, key, value))
       records <- tempRecords.zipWithIndex.map { case ((tp, key, value), i) =>
-        KafkaRecord[String, String](tp, i.toLong, key, value) }
+        ConsumerRecord[String, String](tp, i.toLong, key, value) }
     } yield records)
 
-  implicit val byteArrayConsumerRecordsArb: Arbitrary[List[KafkaRecord[Array[Byte], Array[Byte]]]] =
+  implicit val byteArrayConsumerRecordsArb: Arbitrary[List[ConsumerRecord[Array[Byte], Array[Byte]]]] =
     Arbitrary(for{
       topicPartitionList <- topicPartitionListArb.arbitrary
       tempRecords <- Gen.listOfN(1000, for {
@@ -46,7 +47,7 @@ trait DomainArbitraries {
         value <- Gen.listOfN(256, Arbitrary.arbByte.arbitrary)
       } yield (tp, key, value))
       records <- tempRecords.zipWithIndex.map { case ((tp, key, value), i) =>
-        KafkaRecord[Array[Byte], Array[Byte]](tp, i.toLong, key.toArray, value.toArray) }
+        ConsumerRecord[Array[Byte], Array[Byte]](tp, i.toLong, key.toArray, value.toArray) }
     } yield records)
 
   implicit val kafkaEncryptionSettingsArb: Arbitrary[KafkaEncryptionSettings] =

--- a/src/test/scala/org/novelfs/streaming/kafka/DomainArbitraries.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/DomainArbitraries.scala
@@ -1,6 +1,7 @@
 package org.novelfs.streaming.kafka
 
 import org.novelfs.streaming.kafka.consumer.{ConsumerRecord, KafkaConsumerConfig, OffsetMetadata}
+import org.novelfs.streaming.kafka.producer.ProducerRecord
 import org.scalacheck.{Arbitrary, Gen}
 
 import scala.concurrent.duration._
@@ -49,6 +50,13 @@ trait DomainArbitraries {
       records <- tempRecords.zipWithIndex.map { case ((tp, key, value), i) =>
         ConsumerRecord[Array[Byte], Array[Byte]](tp, i.toLong, key.toArray, value.toArray) }
     } yield records)
+
+  implicit val stringProducerRecord : Arbitrary[ProducerRecord[String, String]] =
+    Arbitrary(for {
+      topic <- Gen.alphaStr
+      key <- Gen.alphaStr
+      value <- Gen.alphaStr
+    } yield ProducerRecord(topic, None, key, value))
 
   implicit val kafkaEncryptionSettingsArb: Arbitrary[KafkaEncryptionSettings] =
     Arbitrary(for {

--- a/src/test/scala/org/novelfs/streaming/kafka/KafkaConsumerConfigSpec.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/KafkaConsumerConfigSpec.scala
@@ -3,6 +3,7 @@ package org.novelfs.streaming.kafka
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.config.SslConfigs
+import org.novelfs.streaming.kafka.consumer.KafkaConsumerConfig
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.prop.GeneratorDrivenPropertyChecks

--- a/src/test/scala/org/novelfs/streaming/kafka/KafkaConsumerSpec.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/KafkaConsumerSpec.scala
@@ -44,17 +44,17 @@ class KafkaConsumerSpec extends FlatSpec with Matchers with MockFactory with Gen
 
   "accumulate offset metadata" should "return the largest offsets for each topic/partition" in {
     forAll { consumerRecords: List[consumer.ConsumerRecord[String, String]] =>
-      val finalMap = Stream.emits(consumerRecords)
+      val finalMap: Map[TopicPartition, OffsetMetadata] = Stream.emits(consumerRecords)
           .through(KafkaConsumer.accumulateOffsetMetadata)
           .map{case (_, offsets) => offsets}
           .toVector
           .last
 
-      val expectedMap =
+      val expectedMap: Map[TopicPartition, OffsetMetadata] =
         consumerRecords.groupBy(_.topicPartition)
-          .map{ case (k, v) => k -> v.map(_.offset).max }
+          .map{ case (k, v) => k -> OffsetMetadata(v.map(_.offset).max) }
 
-      finalMap === expectedMap
+      finalMap shouldBe expectedMap
     }
   }
 

--- a/src/test/scala/org/novelfs/streaming/kafka/KafkaConsumerSpec.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/KafkaConsumerSpec.scala
@@ -75,11 +75,11 @@ class KafkaConsumerSpec extends FlatSpec with Matchers with MockFactory with Gen
           .map(r => (r.key, r.value))
           .unzip
 
-      val expectedKeys: List[Array[Int]] = consumerRecords.map(c => TestHelpers.byteArrayToIntArray(c.key)).toList
-      val expectedVals: List[Array[Int]] = consumerRecords.map(c => TestHelpers.byteArrayToIntArray(c.value)).toList
+      val expectedKeys: List[Array[Int]] = consumerRecords.map(c => TestHelpers.byteArrayToIntArray(c.key))
+      val expectedVals: List[Array[Int]] = consumerRecords.map(c => TestHelpers.byteArrayToIntArray(c.value))
 
-      ks === expectedKeys
-      vs === expectedVals
+      ks should contain theSameElementsAs expectedKeys
+      vs should contain theSameElementsAs expectedVals
     }
   }
 

--- a/src/test/scala/org/novelfs/streaming/kafka/KafkaConsumerSpec.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/KafkaConsumerSpec.scala
@@ -42,7 +42,7 @@ class KafkaConsumerSpec extends FlatSpec with Matchers with MockFactory with Gen
 
       val errorSignal = async.signalOf[IO, Boolean](false).unsafeRunSync()
 
-      KafkaConsumer.commitOffsetMap[IO, String, String](kafkaConsumer)(offsetMap)(errorSignal).unsafeRunSync()
+      (KafkaConsumer.commitOffsetMap[IO, String, String](kafkaConsumer)(offsetMap)(errorSignal) *> IO{Thread.sleep(500)}).unsafeRunSync()
     }
   }
 

--- a/src/test/scala/org/novelfs/streaming/kafka/KafkaConsumerSpec.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/KafkaConsumerSpec.scala
@@ -57,7 +57,9 @@ class KafkaConsumerSpec extends FlatSpec with Matchers with MockFactory with Gen
 
       KafkaConsumer.commitOffsetMap[IO, String, String](kafkaConsumer)(offsetMap)(errorSignal).unsafeRunSync()
 
-      (IO{Thread.sleep(100)} *> errorSignal.get).unsafeRunSync() shouldBe true
+      val signalTrue = errorSignal.discrete.dropWhile(!_).head.compile.toList.unsafeRunSync().head
+
+      signalTrue shouldBe true
     }
   }
 

--- a/src/test/scala/org/novelfs/streaming/kafka/KafkaProducerIntegrationSpec.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/KafkaProducerIntegrationSpec.scala
@@ -1,0 +1,76 @@
+package org.novelfs.streaming.kafka
+
+import cats.effect.IO
+import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
+import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}
+import org.novelfs.streaming.kafka.producer.{KafkaProducer, KafkaProducerConfig, ProducerRecord}
+import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import fs2._
+import org.novelfs.streaming.kafka.consumer.{KafkaConsumer, KafkaConsumerConfig}
+import org.scalatest.tagobjects.Slow
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.Random
+
+class KafkaProducerIntegrationSpec extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks with DomainArbitraries with EmbeddedKafka {
+
+  implicit val config = EmbeddedKafkaConfig(kafkaPort = 7001, zooKeeperPort = 7000)
+  val brokers = List("localhost:7001")
+  val stringSerialiser = new StringSerializer()
+  val stringDeserialiser = new StringDeserializer()
+
+  "Concurrently producing and consuming records to/from a topic" should "result in all produced records being made available to the consumer" taggedAs (Slow) in {
+    withRunningKafka {
+      forAll { (producerRecords: List[ProducerRecord[String, String]]) =>
+        val topicName = "topic-" +Random.alphanumeric.take(20).mkString
+        createCustomTopic(topicName)
+        val topicCorrectProducerRecords = producerRecords.map(_.copy(topic = topicName))
+
+        val producerConfig = KafkaProducerConfig(
+          brokers = brokers,
+          security = KafkaSecuritySettings.NoSecurity,
+          keySerializer = stringSerialiser,
+          valueSerializer = stringSerialiser
+        )
+
+        val consumerConfig = KafkaConsumerConfig(
+          brokers = brokers,
+          security = KafkaSecuritySettings.NoSecurity,
+          topics = List(topicName),
+          clientId = "test",
+          groupId = "test",
+          keyDeserializer = stringDeserialiser,
+          valueDeserializer = stringDeserialiser
+        )
+
+        val consumerStream = KafkaConsumer[IO, String, String](consumerConfig)
+        val producerStream = Stream.emits(topicCorrectProducerRecords)
+          .covary[IO]
+          .through(KafkaProducer(producerConfig))
+
+        // run the consumer stream and producer stream in parallel and collect up the results into a list
+        val results =
+          consumerStream
+          .concurrently(producerStream)
+          .collect {
+            case Right(r) => r
+          }
+          .take(producerRecords.size.toLong)
+          .compile
+          .toList
+          .unsafeRunSync()
+
+        val expectedKeys = producerRecords.map(_.key)
+        val expectedVals = producerRecords.map(_.value)
+
+        val ks = results.map(_.key)
+        val vs = results.map(_.value)
+
+        ks should contain theSameElementsAs expectedKeys
+        vs should contain theSameElementsAs expectedVals
+      }
+    }
+  }
+
+}

--- a/src/test/scala/org/novelfs/streaming/kafka/KafkaProducerSpec.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/KafkaProducerSpec.scala
@@ -1,14 +1,21 @@
 package org.novelfs.streaming.kafka
 
 import cats.effect.IO
-import org.novelfs.streaming.kafka.producer.{KafkaProducer}
+import org.novelfs.streaming.kafka.producer.{KafkaProducer, ProducerRecord}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
-import org.apache.kafka.clients.producer.{Producer => ApacheKafkaProducer}
+import org.apache.kafka.clients.producer.{RecordMetadata, Producer => ApacheKafkaProducer}
+import KafkaSdkConversions._
+import org.apache.kafka.clients
 
 class KafkaProducerSpec extends FlatSpec with Matchers with MockFactory with GeneratorDrivenPropertyChecks with DomainArbitraries  {
-  val rawKafkaProducer = mock[ApacheKafkaProducer[String, String]]
+
+  trait StringApacheKafkaProducer extends ApacheKafkaProducer[String, String] {
+    override def send(record: clients.producer.ProducerRecord[String, String]): java.util.concurrent.Future[RecordMetadata]
+  }
+
+  val rawKafkaProducer = mock[StringApacheKafkaProducer]
   val kafkaProducer = KafkaProducer(rawKafkaProducer)
 
   "cleanupProducer" should "call producer.close()" in {
@@ -16,5 +23,12 @@ class KafkaProducerSpec extends FlatSpec with Matchers with MockFactory with Gen
     KafkaProducer.cleanupProducer[IO, String, String](kafkaProducer).unsafeRunSync()
   }
 
+  "sendRecord" should "call producer.send()" in {
+    forAll { record : ProducerRecord[String, String] =>
+      val apacheRecord = record.toKafkaSdk
+      (rawKafkaProducer.send : org.apache.kafka.clients.producer.ProducerRecord[String, String] => java.util.concurrent.Future[RecordMetadata]) expects(apacheRecord) once()
 
+      KafkaProducer.sendRecord[IO, String, String](record)(kafkaProducer).unsafeRunSync()
+    }
+  }
 }

--- a/src/test/scala/org/novelfs/streaming/kafka/KafkaProducerSpec.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/KafkaProducerSpec.scala
@@ -1,0 +1,21 @@
+package org.novelfs.streaming.kafka
+
+import cats.effect.IO
+import org.novelfs.streaming.kafka.producer.{KafkaProducer, ProducerRecord}
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.apache.kafka.clients.producer.{RecordMetadata, Producer => ApacheKafkaProducer}
+import KafkaSdkConversions._
+
+class KafkaProducerSpec extends FlatSpec with Matchers with MockFactory with GeneratorDrivenPropertyChecks with DomainArbitraries  {
+  val rawKafkaProducer = mock[ApacheKafkaProducer[String, String]]
+  val kafkaProducer = KafkaProducer(rawKafkaProducer)
+
+  "cleanupProducer" should "call producer.close()" in {
+    (rawKafkaProducer.close _ : () => Unit) expects() once()
+    KafkaProducer.cleanupProducer[IO, String, String](kafkaProducer).unsafeRunSync()
+  }
+
+  
+}

--- a/src/test/scala/org/novelfs/streaming/kafka/KafkaProducerSpec.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/KafkaProducerSpec.scala
@@ -1,12 +1,11 @@
 package org.novelfs.streaming.kafka
 
 import cats.effect.IO
-import org.novelfs.streaming.kafka.producer.{KafkaProducer, ProducerRecord}
+import org.novelfs.streaming.kafka.producer.{KafkaProducer}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
-import org.apache.kafka.clients.producer.{RecordMetadata, Producer => ApacheKafkaProducer}
-import KafkaSdkConversions._
+import org.apache.kafka.clients.producer.{Producer => ApacheKafkaProducer}
 
 class KafkaProducerSpec extends FlatSpec with Matchers with MockFactory with GeneratorDrivenPropertyChecks with DomainArbitraries  {
   val rawKafkaProducer = mock[ApacheKafkaProducer[String, String]]
@@ -17,5 +16,5 @@ class KafkaProducerSpec extends FlatSpec with Matchers with MockFactory with Gen
     KafkaProducer.cleanupProducer[IO, String, String](kafkaProducer).unsafeRunSync()
   }
 
-  
+
 }

--- a/src/test/scala/org/novelfs/streaming/kafka/KafkaProducerSpec.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/KafkaProducerSpec.scala
@@ -1,5 +1,7 @@
 package org.novelfs.streaming.kafka
 
+import java.nio.charset.Charset
+
 import cats.effect.IO
 import org.novelfs.streaming.kafka.producer.{KafkaProducer, ProducerRecord}
 import org.scalamock.scalatest.MockFactory
@@ -7,7 +9,9 @@ import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.apache.kafka.clients.producer.{RecordMetadata, Producer => ApacheKafkaProducer}
 import KafkaSdkConversions._
+import fs2.Stream
 import org.apache.kafka.clients
+import org.apache.kafka.common.serialization.Serializer
 
 class KafkaProducerSpec extends FlatSpec with Matchers with MockFactory with GeneratorDrivenPropertyChecks with DomainArbitraries  {
 
@@ -29,6 +33,31 @@ class KafkaProducerSpec extends FlatSpec with Matchers with MockFactory with Gen
       (rawKafkaProducer.send : org.apache.kafka.clients.producer.ProducerRecord[String, String] => java.util.concurrent.Future[RecordMetadata]) expects(apacheRecord) once()
 
       KafkaProducer.sendRecord[IO, String, String](record)(kafkaProducer).unsafeRunSync()
+    }
+  }
+
+  "serializer" should "call serialize on the key and value serializers with the supplied stream values" in {
+    forAll { producerRecords: List[ProducerRecord[String, String]] =>
+      val stringSerialiser = mock[Serializer[String]]
+
+      (stringSerialiser.serialize (_ : String, _ : String)) expects(*, *) onCall((_, str) => str.getBytes(Charset.forName("UTF-8"))) atLeastOnce()
+
+      val (ks, vs) =
+        Stream.emits(producerRecords)
+          .covary[IO]
+          .through(KafkaProducer.serializer[IO, String, String](stringSerialiser, stringSerialiser))
+          .collect { case Right(r) => r }
+          .compile
+          .toList
+          .unsafeRunSync()
+          .map(r => (r.key, r.value))
+          .unzip
+
+      val expectedKeys: List[Array[Byte]] = producerRecords.map(c => c.key.getBytes(Charset.forName("UTF-8")))
+      val expectedVals: List[Array[Byte]] = producerRecords.map(c => c.value.getBytes(Charset.forName("UTF-8")))
+
+      ks should contain theSameElementsAs expectedKeys
+      vs should contain theSameElementsAs expectedVals
     }
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.1"
+version in ThisBuild := "0.2.1"


### PR DESCRIPTION
Added a kafka producer:
- Apply creates a catch-all producing pipe that sends all producer records flowing downstream to Kafka
- The serializer pipe converts to producer records of byte arrays
- Not much customisation is provided for the producer at the moment, mostly default config is used

Other changes:
- Changed the logic of committing offsets in the consumer to optimistically commit and then fail the stream in the event of a callback error
