### PR TITLE
Periodic commit

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,13 +4,14 @@ name := "streaming-kafka"
 scalaVersion := "2.12.4"
 organization := "org.novelfs"
 
-val catsEffectVersion = "0.8"
+val catsEffectVersion = "1.0.0-RC2"
 val kafkaSerializationV = "0.3.2"
 val scalatestVersion = "3.0.4"
 val typesafeConfigVersion = "1.3.1"
 
 libraryDependencies ++= Seq(
-  "com.typesafe" % "config" % typesafeConfigVersion
+  "ch.qos.logback" % "logback-classic" % "1.2.3" % Test
+  , "com.typesafe" % "config" % typesafeConfigVersion
   , "org.scalactic" %% "scalactic" % scalatestVersion
   , "org.scalatest" %% "scalatest" % scalatestVersion % Test
   , "org.scalamock" %% "scalamock" % "4.1.0" % Test

--- a/build.sbt
+++ b/build.sbt
@@ -1,25 +1,23 @@
 import ReleaseTransformations._
 
 name := "streaming-kafka"
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.6"
 organization := "org.novelfs"
 
-val catsEffectVersion = "0.8"
 val kafkaSerializationV = "0.3.2"
 val scalatestVersion = "3.0.4"
 val typesafeConfigVersion = "1.3.1"
 
 libraryDependencies ++= Seq(
-  "com.typesafe" % "config" % typesafeConfigVersion
-  , "org.scalactic" %% "scalactic" % scalatestVersion
-  , "org.scalatest" %% "scalatest" % scalatestVersion % Test
-  , "org.scalamock" %% "scalamock" % "4.1.0" % Test
-  , "org.scalacheck" %% "scalacheck" % "1.13.4" % Test
-  , "org.typelevel" %% "cats-effect" % catsEffectVersion
-  , "org.apache.kafka" %% "kafka" % "1.0.0"
-  , "co.fs2" %% "fs2-core" % "0.10.5"
-  , "co.fs2" %% "fs2-io" % "0.10.5"
-  , "net.manub" %% "scalatest-embedded-kafka" % "1.1.0" % Test
+  "com.typesafe"        % "config"                    % typesafeConfigVersion
+  , "org.scalactic"     %% "scalactic"                % scalatestVersion
+  , "org.scalatest"     %% "scalatest"                % scalatestVersion      % Test
+  , "org.scalamock"     %% "scalamock"                % "4.1.0"               % Test
+  , "org.scalacheck"    %% "scalacheck"               % "1.13.4"              % Test
+  , "org.apache.kafka"  %% "kafka"                    % "1.0.0"
+  , "co.fs2"            %% "fs2-core"                 % "0.10.5"
+  , "co.fs2"            %% "fs2-io"                   % "0.10.5"
+  , "net.manub"         %% "scalatest-embedded-kafka" % "1.1.0"               % Test
 )
 
 addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.4")
@@ -96,7 +94,7 @@ scmInfo := Some(
 )
 
 releaseCrossBuild := true
-crossScalaVersions := Seq("2.11.12", "2.12.4")
+crossScalaVersions := Seq("2.11.12", "2.12.6")
 
 useGpg := false
 pgpSecretRing := file("local.secring.gpg")

--- a/src/main/scala/org/novelfs/streaming/kafka/algebra/KafkaConsumerAlg.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/algebra/KafkaConsumerAlg.scala
@@ -10,16 +10,16 @@ trait KafkaConsumerAlg[F[_], TContext[_, _]] {
   /**
     * An effect to commit supplied map of offset metadata for each topic/partition pair
     */
-  def commitOffsetMap[K, V](offsetMap : Map[TopicPartition, OffsetMetadata])(consumer: TContext[K, V]): F[Unit]
+  def commitOffsetMap[K, V](offsetMap : Map[TopicPartition, OffsetMetadata])(context: TContext[K, V]): F[Unit]
 
   /**
     * An effect that polls kafka (once) with a supplied timeout
     */
-  def poll[K, V](pollTimeout : FiniteDuration)(consumer: TContext[K, V]) : F[Vector[ConsumerRecord[K, V]]]
+  def poll[K, V](pollTimeout : FiniteDuration)(context: TContext[K, V]) : F[Vector[ConsumerRecord[K, V]]]
 
   /**
     * An effect to return the set of topic and partition assignments attached to the supplied consumer
     */
-  def topicPartitionAssignments[K, V](consumer: TContext[K, V]): F[Set[TopicPartition]]
+  def topicPartitionAssignments[K, V](context: TContext[K, V]): F[Set[TopicPartition]]
 
 }

--- a/src/main/scala/org/novelfs/streaming/kafka/algebra/KafkaConsumerAlg.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/algebra/KafkaConsumerAlg.scala
@@ -1,0 +1,25 @@
+package org.novelfs.streaming.kafka.algebra
+
+import org.novelfs.streaming.kafka.TopicPartition
+import org.novelfs.streaming.kafka.consumer.{ConsumerRecord, OffsetMetadata}
+
+import scala.concurrent.duration.FiniteDuration
+
+trait KafkaConsumerAlg[F[_], TContext[_, _]] {
+
+  /**
+    * An effect to commit supplied map of offset metadata for each topic/partition pair
+    */
+  def commitOffsetMap[K, V](offsetMap : Map[TopicPartition, OffsetMetadata])(consumer: TContext[K, V]): F[Unit]
+
+  /**
+    * An effect that polls kafka (once) with a supplied timeout
+    */
+  def poll[K, V](pollTimeout : FiniteDuration)(consumer: TContext[K, V]) : F[Vector[ConsumerRecord[K, V]]]
+
+  /**
+    * An effect to return the set of topic and partition assignments attached to the supplied consumer
+    */
+  def topicPartitionAssignments[K, V](consumer: TContext[K, V]): F[Set[TopicPartition]]
+
+}

--- a/src/main/scala/org/novelfs/streaming/kafka/consumer/KafkaConsumer.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/consumer/KafkaConsumer.scala
@@ -14,6 +14,7 @@ import scala.concurrent.duration.FiniteDuration
 import cats.Functor
 import fs2.async.mutable.{Queue, Signal}
 import KafkaSdkConversions._
+import cats.effect.concurrent.MVar
 
 final case class KafkaConsumer[K, V] private (kafkaConsumer : ApacheKafkaConsumer[K, V])
 
@@ -24,14 +25,20 @@ object KafkaConsumer {
   /**
     * An effect to commit supplied map of offset metadata for each topic/partition pair
     */
-  def commitOffsetMap[F[_] : Effect, K, V](consumer : KafkaConsumer[K, V])(offsetMap : Map[TopicPartition, OffsetMetadata])(errorSignal : Signal[F, Boolean])(implicit ec: ExecutionContext): F[Unit] =
-    Effect[F].delay {
-      println(errorSignal)
-      println(ec)
-      consumer.kafkaConsumer.commitSync(offsetMap.toKafkaSdk)
-      log.debug(s"Offset committed: $offsetMap")
-      println(s"Offset committed: $offsetMap")
-    }.onError{case ex => Effect[F].delay{println(ex)}}
+  def commitOffsetMap[F[_] : Effect, K, V](consumerVar : MVar[F, KafkaConsumer[K, V]])(offsetMap : Map[TopicPartition, OffsetMetadata])(errorSignal : Signal[F, Boolean])(implicit ec: ExecutionContext): F[Unit] =
+    for {
+      consumer <- consumerVar.take
+      _ <- Effect[F].delay {
+          println(ec)
+          consumer.kafkaConsumer.commitSync(offsetMap.toKafkaSdk)
+          log.debug(s"Offset committed: $offsetMap")
+        }.onError{case ex =>
+          log.error("Error during offset commit", ex)
+          errorSignal.set(true)
+        }
+      _ <- consumerVar.put(consumer)
+    } yield ()
+
 
   /**
     * A pipe that accumulates the offset metadata for each topic/partition pair for the supplied input stream of Consumer Records
@@ -50,22 +57,14 @@ object KafkaConsumer {
   /**
     * A stream that commits the offsets in the supplied queue to kafka, using the supplied kafka consumer every supplied timeBetweenCommits
     */
-  def commitOffsetsFromQueueEvery[F[_] : Effect, K, V](timeBetweenCommits : FiniteDuration)(consumer : KafkaConsumer[K, V])(queue : Queue[F, Map[TopicPartition, OffsetMetadata]])(implicit ec : ExecutionContext): Stream[F, Unit] =
+  def commitOffsetsFromQueueEvery[F[_] : Effect, K, V](timeBetweenCommits : FiniteDuration)(consumer : MVar[F, KafkaConsumer[K, V]])(errorSignal : Signal[F, Boolean])(queue : Queue[F, Map[TopicPartition, OffsetMetadata]])(implicit ec : ExecutionContext): Stream[F, Unit] =
     for {
       obs <- async.hold(Map.empty[TopicPartition, OffsetMetadata], queue.dequeue)
-      errorSignal <- Stream.eval(async.signalOf[F, Boolean](false))
-      xs <- Scheduler[F](corePoolSize = 2).flatMap(scheduler =>
-        scheduler.fixedRate(timeBetweenCommits).evalMap(_ =>  {
-            println("jodsjfdsf")
-            obs.get
-          })
-        ).evalMap { offsetMap => commitOffsetMap(consumer)(offsetMap)(errorSignal) }
-      //errorSignal <- Stream.eval(async.signalOf[F, Boolean](false))
-      //xs <- queue.dequeue
-//        .takeElementsEvery(timeBetweenCommits)
-  //      .evalMap { offsetMap => commitOffsetMap(consumer)(offsetMap)(errorSignal) }
+      scheduler <- Scheduler[F](corePoolSize = 2)
+      xs <- scheduler
+        .fixedRate(timeBetweenCommits).evalMap(_ => obs.get)
+        .evalMap { offsetMap => commitOffsetMap(consumer)(offsetMap)(errorSignal) }
     } yield xs
-
 
   /**
     * An effect that generates a subscription to some Kafka topics/paritions using the supplied kafka config
@@ -76,9 +75,9 @@ object KafkaConsumer {
   /**
     * An effect that generates a subscription to some Kafka topics/paritions using the supplied kafka config
     */
-  def subscribeToConsumer[F[_] : Sync, K, V](config : KafkaConsumerConfig[K, V]): F[KafkaConsumer[Array[Byte], Array[Byte]]] = {
+  def subscribeToConsumer[F[_] : ConcurrentEffect, K, V](config : KafkaConsumerConfig[K, V]): F[MVar[F, KafkaConsumer[Array[Byte], Array[Byte]]]] = {
     val consumer = new ConcreteApacheKafkaConsumer(KafkaConsumerConfig.generateProperties(config), new ByteArrayDeserializer(), new ByteArrayDeserializer())
-    Sync[F].delay (consumer.subscribe(config.topics.asJava)) *> Sync[F].point(KafkaConsumer(consumer))
+    ConcurrentEffect[F].delay (consumer.subscribe(config.topics.asJava)) *> MVar.of[F, KafkaConsumer[Array[Byte], Array[Byte]]](KafkaConsumer(consumer))
   }
 
   def subscribe[F[_] : Sync, K, V](config : KafkaConsumerConfig[K, V])(consumer : KafkaConsumer[K, V]): F[KafkaConsumer[K, V]] = {
@@ -88,15 +87,23 @@ object KafkaConsumer {
   /**
     * An effect that disposes of some supplied kafka consumer
     */
-  def cleanupConsumer[F[_] : Sync, K, V](consumer : KafkaConsumer[K, V]): F[Unit] =
-    Sync[F].delay(consumer.kafkaConsumer.wakeup()) *>
-      Sync[F].delay(consumer.kafkaConsumer.close())
+  def cleanupConsumer[F[_] : Sync, K, V](consumerVar : MVar[F, KafkaConsumer[K, V]]): F[Unit] =
+    for {
+      consumer <- consumerVar.take
+      _ <- Sync[F].delay(consumer.kafkaConsumer.wakeup())
+      _ <- Sync[F].delay(consumer.kafkaConsumer.close())
+    } yield ()
 
   /**
     * An effect that polls kafka (once) with a supplied timeout
     */
-  def pollKafka[F[_] : Sync, K, V](consumer : KafkaConsumer[K, V])(pollTimeout : FiniteDuration): F[Vector[ConsumerRecord[K, V]]] =
-    Sync[F].delay(consumer.kafkaConsumer.poll(pollTimeout.toMillis).fromKafkaSdk)
+  def pollKafka[F[_] : Effect, K, V](consumerVar : MVar[F, KafkaConsumer[K, V]])(pollTimeout : FiniteDuration): F[Vector[ConsumerRecord[K, V]]] =
+    for {
+      consumer <- consumerVar.take
+      response <- Sync[F].delay(consumer.kafkaConsumer.poll(pollTimeout.toMillis).fromKafkaSdk)
+      _ <- consumerVar.put(consumer)
+    } yield response
+
 
   /**
     * A pipe that deserialises an array of bytes using supplied key and value deserialisers
@@ -120,27 +127,33 @@ object KafkaConsumer {
   /**
     * A pipe that applies the kafka offset commit settings policy from the config
     */
-  def applyCommitPolicy[F[_] : Effect, K, V](consumer : KafkaConsumer[Array[Byte], Array[Byte]])(config : KafkaConsumerConfig[K, V])(implicit ex : ExecutionContext) : Pipe[F, ConsumerRecord[Array[Byte], Array[Byte]], ConsumerRecord[Array[Byte], Array[Byte]]] =
-    stream => config.commitOffsetSettings match {
-        case KafkaOffsetCommitSettings.AutoCommit(timeBetweenCommits, maxAsyncCommits) =>
+  def applyCommitPolicy[F[_] : Effect, K, V](consumerVar : MVar[F, KafkaConsumer[Array[Byte], Array[Byte]]])(config : KafkaConsumerConfig[K, V])(implicit ex : ExecutionContext) : Pipe[F, ConsumerRecord[Array[Byte], Array[Byte]], ConsumerRecord[Array[Byte], Array[Byte]]] =
+    stream =>
+      config.commitOffsetSettings match {
+        case KafkaOffsetCommitSettings.AutoCommit(timeBetweenCommits) =>
           for {
-            queue <- Stream.eval(Queue.bounded[F, Map[TopicPartition, OffsetMetadata]](maxAsyncCommits))
+            queue <- Stream.eval(Queue.unbounded[F, Map[TopicPartition, OffsetMetadata]])
+            errorSignal <- Stream.eval(async.signalOf[F, Boolean](false))
             y <- stream.through(publishOffsetsToQueue(queue))
-              .concurrently(commitOffsetsFromQueueEvery(timeBetweenCommits)(consumer)(queue))
+              .interruptWhen(errorSignal)
+              .concurrently(commitOffsetsFromQueueEvery(timeBetweenCommits)(consumerVar)(errorSignal)(queue))
           } yield y
         case _ => stream
       }
 
+
   /**
     * Creates a streaming subscription using the supplied kafka configuration
     */
-  def apply[F[_] : Effect, K, V](config : KafkaConsumerConfig[K, V])(implicit ex : ExecutionContext): Stream[F, Either[Throwable, ConsumerRecord[K, V]]] =
-    Stream.bracket(subscribeToConsumer(config))(consumer =>
-      for {
-        records <- Stream.repeatEval(pollKafka(consumer)(config.pollTimeout)).scope
-        process <- Stream.chunk(Chunk.vector(records))
-          .covary[F]
-          .through(applyCommitPolicy(consumer)(config))
-          .through(deserializer(config.keyDeserializer, config.valueDeserializer))
-      } yield process, cleanupConsumer[F, Array[Byte], Array[Byte]])
+  def apply[F[_] : ConcurrentEffect, K, V](config : KafkaConsumerConfig[K, V])(implicit ex : ExecutionContext): Stream[F, Either[Throwable, ConsumerRecord[K, V]]] =
+    Stream.bracket(subscribeToConsumer(config))(consumer => {
+      val stream =
+        for {
+          records <- Stream.repeatEval(pollKafka(consumer)(config.pollTimeout)).scope
+          process <- Stream.chunk(Chunk.vector(records)).covary[F]
+        } yield process
+      stream
+        .through(applyCommitPolicy(consumer)(config))
+        .through(deserializer(config.keyDeserializer, config.valueDeserializer))
+    }, cleanupConsumer[F, Array[Byte], Array[Byte]])
 }

--- a/src/main/scala/org/novelfs/streaming/kafka/consumer/KafkaConsumer.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/consumer/KafkaConsumer.scala
@@ -113,7 +113,7 @@ object KafkaConsumer {
   def apply[F[_] : Effect, K, V](config : KafkaConsumerConfig[K, V])(implicit ex : ExecutionContext): Stream[F, Either[Throwable, ConsumerRecord[K, V]]] =
     Stream.bracket(subscribeToConsumer(config))(consumer =>
       for {
-        records <- Stream.repeatEval(pollKafka(consumer)(config.pollTimeout)).scope
+        records <- Stream.repeatEval(pollKafka(consumer)(config.pollTimeout)).filter(_.nonEmpty)
         process <- Stream.chunk(Chunk.vector(records))
           .covary[F]
           .observe(s =>

--- a/src/main/scala/org/novelfs/streaming/kafka/consumer/KafkaConsumer.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/consumer/KafkaConsumer.scala
@@ -3,7 +3,6 @@ package org.novelfs.streaming.kafka.consumer
 import cats.effect._
 import cats.implicits._
 import fs2._
-import org.apache.kafka.clients.consumer.{Consumer => ApacheKafkaConsumer}
 import org.apache.kafka.common.serialization.{ByteArrayDeserializer, Deserializer}
 import org.novelfs.streaming.kafka._
 import org.slf4j.LoggerFactory
@@ -14,8 +13,6 @@ import cats.Functor
 import fs2.async.mutable.{Queue, Signal}
 import cats.effect.concurrent.MVar
 import org.novelfs.streaming.kafka.interpreter.ThinKafkaConsumerClient
-
-final case class KafkaConsumer[K, V] private (kafkaConsumer : ApacheKafkaConsumer[K, V])
 
 object KafkaConsumer {
 

--- a/src/main/scala/org/novelfs/streaming/kafka/consumer/KafkaConsumerConfig.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/consumer/KafkaConsumerConfig.scala
@@ -38,9 +38,9 @@ object KafkaConsumerConfig {
       topics = topics,
       clientId = clientId,
       groupId = groupId,
-      commitOffsetSettings = KafkaOffsetCommitSettings.AutoCommit(500.milliseconds, 10),
-      pollTimeout = 500.milliseconds,
-      maxPollRecords = 100,
+      commitOffsetSettings = KafkaOffsetCommitSettings.AutoCommit(500.milliseconds, 10000000),
+      pollTimeout = 50000.milliseconds,
+      maxPollRecords = 10000,
       keyDeserializer = keyDeserializer,
       valueDeserializer = valueDeserializer)
 

--- a/src/main/scala/org/novelfs/streaming/kafka/consumer/KafkaConsumerConfig.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/consumer/KafkaConsumerConfig.scala
@@ -38,8 +38,8 @@ object KafkaConsumerConfig {
       topics = topics,
       clientId = clientId,
       groupId = groupId,
-      commitOffsetSettings = KafkaOffsetCommitSettings.AutoCommit(500.milliseconds, 10000000),
-      pollTimeout = 50000.milliseconds,
+      commitOffsetSettings = KafkaOffsetCommitSettings.AutoCommit(500.milliseconds),
+      pollTimeout = 5000.milliseconds,
       maxPollRecords = 10000,
       keyDeserializer = keyDeserializer,
       valueDeserializer = valueDeserializer)

--- a/src/main/scala/org/novelfs/streaming/kafka/consumer/KafkaConsumerSubscription.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/consumer/KafkaConsumerSubscription.scala
@@ -1,0 +1,26 @@
+package org.novelfs.streaming.kafka.consumer
+
+import cats.implicits._
+import cats.effect.Sync
+import org.apache.kafka.clients.consumer.{Consumer => ApacheKafkaConsumer, KafkaConsumer => ConcreteApacheKafkaConsumer}
+import scala.collection.JavaConverters._
+
+final case class KafkaConsumerSubscription[K, V] private (kafkaConsumer : ApacheKafkaConsumer[K, V])
+
+object KafkaConsumerSubscription {
+
+  /**
+    * An effect that generates a subscription to some Kafka topics/paritions using the supplied kafka config
+    */
+  def apply[F[_] : Sync, K, V](config : KafkaConsumerConfig[K, V]): F[KafkaConsumerSubscription[K, V]] = {
+    val consumer = new ConcreteApacheKafkaConsumer(KafkaConsumerConfig.generateProperties(config), config.keyDeserializer, config.valueDeserializer)
+    Sync[F].delay (consumer.subscribe(config.topics.asJava)) *> Sync[F].pure(KafkaConsumerSubscription(consumer))
+  }
+
+  /**
+    * An effect that disposes of some supplied subscription
+    */
+  def cleanup[F[_] : Sync, K, V](subscription : KafkaConsumerSubscription[K, V]): F[Unit] =
+    Sync[F].delay(subscription.kafkaConsumer.wakeup()) *> Sync[F].delay(subscription.kafkaConsumer.close())
+
+}

--- a/src/main/scala/org/novelfs/streaming/kafka/consumer/KafkaOffsetCommitSettings.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/consumer/KafkaOffsetCommitSettings.scala
@@ -5,5 +5,5 @@ import scala.concurrent.duration.FiniteDuration
 sealed trait KafkaOffsetCommitSettings
 object KafkaOffsetCommitSettings {
   final case object DoNotCommit extends KafkaOffsetCommitSettings
-  final case class AutoCommit(timeBetweenCommits: FiniteDuration, maxAsyncCommits: Int) extends KafkaOffsetCommitSettings
+  final case class AutoCommit(timeBetweenCommits: FiniteDuration) extends KafkaOffsetCommitSettings
 }

--- a/src/main/scala/org/novelfs/streaming/kafka/interpreter/ThinKafkaConsumerClient.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/interpreter/ThinKafkaConsumerClient.scala
@@ -1,0 +1,40 @@
+package org.novelfs.streaming.kafka.interpreter
+
+import cats.effect.Sync
+import org.novelfs.streaming.kafka.algebra.KafkaConsumerAlg
+import org.novelfs.streaming.kafka.TopicPartition
+import org.novelfs.streaming.kafka.consumer.{ConsumerRecord, KafkaConsumerSubscription, OffsetMetadata}
+import org.slf4j.LoggerFactory
+import org.novelfs.streaming.kafka.KafkaSdkConversions._
+
+import scala.concurrent.duration.FiniteDuration
+
+object ThinKafkaConsumerClient {
+
+  def apply[F[_] : Sync]: KafkaConsumerAlg[F, KafkaConsumerSubscription] = new KafkaConsumerAlg[F, KafkaConsumerSubscription] {
+
+    private val log = LoggerFactory.getLogger(ThinKafkaConsumerClient.getClass)
+
+    /**
+      * An effect to commit supplied map of offset metadata for each topic/partition pair
+      */
+    override def commitOffsetMap[K, V](offsetMap: Map[TopicPartition, OffsetMetadata])(consumer: KafkaConsumerSubscription[K, V]): F[Unit] =
+      Sync[F].delay {
+        consumer.kafkaConsumer.commitSync(offsetMap.toKafkaSdk)
+        log.debug(s"Offset committed: $offsetMap")
+      }
+
+    /**
+      * An effect that polls kafka (once) with a supplied timeout
+      */
+    override def poll[K, V](pollTimeout: FiniteDuration)(consumer: KafkaConsumerSubscription[K, V]): F[Vector[ConsumerRecord[K, V]]] =
+      Sync[F].delay(consumer.kafkaConsumer.poll(pollTimeout.toMillis).fromKafkaSdk)
+
+    /**
+      * An effect to return the set of topic and partition assignments attached to the supplied consumer
+      */
+    override def topicPartitionAssignments[K, V](consumer: KafkaConsumerSubscription[K, V]): F[Set[TopicPartition]] =
+      Sync[F].delay { consumer.kafkaConsumer.assignment().fromKafkaSdk }
+  }
+
+}

--- a/src/main/scala/org/novelfs/streaming/kafka/utils/package.scala
+++ b/src/main/scala/org/novelfs/streaming/kafka/utils/package.scala
@@ -1,0 +1,16 @@
+package org.novelfs.streaming.kafka
+
+import cats.implicits._
+import cats.effect.ConcurrentEffect
+import cats.effect.concurrent.MVar
+
+package object utils {
+  implicit class MVarOps[F[_] : ConcurrentEffect, A](val mvar : MVar[F, A]) {
+    def locked[B](f : A => F[B]): F[B] =
+      for {
+        item <- mvar.take
+        result <- f(item)
+        _ <- mvar.put(item)
+      } yield result
+  }
+}

--- a/src/test/scala/org/novelfs/streaming/kafka/KafkaConsumerSpec.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/KafkaConsumerSpec.scala
@@ -1,109 +1,109 @@
-package org.novelfs.streaming.kafka
-
-import cats.implicits._
-import cats.effect._
-import org.scalamock.scalatest.MockFactory
-import org.scalatest.{FlatSpec, Matchers}
-import org.apache.kafka.clients.consumer.{ConsumerRecord => ApacheConsumerRecord, ConsumerRecords => ApacheConsumerRecords, OffsetCommitCallback, Consumer => ApacheKafkaConsumer}
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
-
-import scala.concurrent.duration._
-import collection.JavaConverters._
-import fs2._
-import org.apache.kafka.common.serialization.Deserializer
-import KafkaSdkConversions._
-import org.novelfs.streaming.kafka.consumer.{KafkaConsumer, OffsetMetadata}
-import scala.concurrent.ExecutionContext.Implicits.global
-
-class KafkaConsumerSpec extends FlatSpec with Matchers with MockFactory with GeneratorDrivenPropertyChecks with DomainArbitraries {
-
-  val rawKafkaConsumer = mock[ApacheKafkaConsumer[String, String]]
-  val kafkaConsumer = KafkaConsumer(rawKafkaConsumer)
-
-  "cleanupConsumer" should "call consumer.wakeup() and consumer.close()" in {
-    (rawKafkaConsumer.wakeup _ : () => Unit) expects() once()
-    (rawKafkaConsumer.close _ : () => Unit) expects() once()
-    KafkaConsumer.cleanupConsumer[IO, String, String](kafkaConsumer).unsafeRunSync()
-  }
-
-  "poll" should "call consumer.poll with supplied duration" in {
-    forAll { (d: FiniteDuration) =>
-      (rawKafkaConsumer.poll _) expects(d.toMillis) returns
-        (new ApacheConsumerRecords[String,String](Map.empty[org.apache.kafka.common.TopicPartition, java.util.List[ApacheConsumerRecord[String, String]]].asJava)) once()
-      KafkaConsumer.pollKafka[IO, String, String](kafkaConsumer)(d).unsafeRunSync()
-    }
-  }
-
-  "commit offset map" should "call consumer.commitAsync with the supplied OffsetMap" in {
-    forAll { (offsetMap : Map[TopicPartition, OffsetMetadata]) =>
-      val javaMap = offsetMap.toKafkaSdk
-
-      (rawKafkaConsumer.commitAsync(_ : java.util.Map[org.apache.kafka.common.TopicPartition,  org.apache.kafka.clients.consumer.OffsetAndMetadata], _ : OffsetCommitCallback))
-        .expects (javaMap, *) onCall { (_, callback) => callback.onComplete(javaMap, null) } once()
-
-      val errorSignal = async.signalOf[IO, Boolean](false).unsafeRunSync()
-
-      (KafkaConsumer.commitOffsetMap[IO, String, String](kafkaConsumer)(offsetMap)(errorSignal) *> IO{Thread.sleep(500)}).unsafeRunSync()
-    }
-  }
-
-  "commit offset map" should "trigger the error signal if an error was received from the callback" in {
-    forAll { (offsetMap : Map[TopicPartition, OffsetMetadata]) =>
-      val javaMap = offsetMap.toKafkaSdk
-
-      (rawKafkaConsumer.commitAsync(_ : java.util.Map[org.apache.kafka.common.TopicPartition,  org.apache.kafka.clients.consumer.OffsetAndMetadata], _ : OffsetCommitCallback))
-        .expects (javaMap, *) onCall { (_, callback) => callback.onComplete(javaMap, new Exception("Red alert!")) } once()
-
-      val errorSignal = async.signalOf[IO, Boolean](false).unsafeRunSync()
-
-      KafkaConsumer.commitOffsetMap[IO, String, String](kafkaConsumer)(offsetMap)(errorSignal).unsafeRunSync()
-
-      val signalTrue = errorSignal.discrete.dropWhile(!_).head.compile.toList.unsafeRunSync().head
-
-      signalTrue shouldBe true
-    }
-  }
-
-  "accumulate offset metadata" should "return the largest offsets for each topic/partition" in {
-    forAll { consumerRecords: List[consumer.ConsumerRecord[String, String]] =>
-      val finalMap: Map[TopicPartition, OffsetMetadata] = Stream.emits(consumerRecords)
-          .through(KafkaConsumer.accumulateOffsetMetadata)
-          .map{case (_, offsets) => offsets}
-          .toVector
-          .last
-
-      val expectedMap: Map[TopicPartition, OffsetMetadata] =
-        consumerRecords.groupBy(_.topicPartition)
-          .map{ case (k, v) => k -> OffsetMetadata(v.map(_.offset).max) }
-
-      finalMap shouldBe expectedMap
-    }
-  }
-
-  "deserializer" should "call deserialize on the key and value deserializers with the supplied stream values" in {
-    forAll { consumerRecords: List[consumer.ConsumerRecord[Array[Byte], Array[Byte]]] =>
-      val intDeserializer = mock[Deserializer[Array[Int]]]
-
-      (intDeserializer.deserialize (_ : String, _ : Array[Byte])) expects(*, *) onCall((_, arr) => TestHelpers.byteArrayToIntArray(arr)) atLeastOnce()
-
-      val (ks, vs) =
-        Stream.emits(consumerRecords)
-          .covary[IO]
-          .through(KafkaConsumer.deserializer[IO, Array[Int], Array[Int]](intDeserializer, intDeserializer))
-          .collect { case Right(r) => r }
-          .compile
-          .toList
-          .unsafeRunSync()
-          .map(r => (r.key, r.value))
-          .unzip
-
-      val expectedKeys: List[Array[Int]] = consumerRecords.map(c => TestHelpers.byteArrayToIntArray(c.key))
-      val expectedVals: List[Array[Int]] = consumerRecords.map(c => TestHelpers.byteArrayToIntArray(c.value))
-
-      ks should contain theSameElementsAs expectedKeys
-      vs should contain theSameElementsAs expectedVals
-    }
-  }
-
-
-}
+//package org.novelfs.streaming.kafka
+//
+//import cats.implicits._
+//import cats.effect._
+//import org.scalamock.scalatest.MockFactory
+//import org.scalatest.{FlatSpec, Matchers}
+//import org.apache.kafka.clients.consumer.{ConsumerRecord => ApacheConsumerRecord, ConsumerRecords => ApacheConsumerRecords, OffsetCommitCallback, Consumer => ApacheKafkaConsumer}
+//import org.scalatest.prop.GeneratorDrivenPropertyChecks
+//
+//import scala.concurrent.duration._
+//import collection.JavaConverters._
+//import fs2._
+//import org.apache.kafka.common.serialization.Deserializer
+//import KafkaSdkConversions._
+//import org.novelfs.streaming.kafka.consumer.{KafkaConsumer, OffsetMetadata}
+//import scala.concurrent.ExecutionContext.Implicits.global
+//
+//class KafkaConsumerSpec extends FlatSpec with Matchers with MockFactory with GeneratorDrivenPropertyChecks with DomainArbitraries {
+//
+//  val rawKafkaConsumer = mock[ApacheKafkaConsumer[String, String]]
+//  val kafkaConsumer = KafkaConsumer(rawKafkaConsumer)
+//
+//  "cleanupConsumer" should "call consumer.wakeup() and consumer.close()" in {
+//    (rawKafkaConsumer.wakeup _ : () => Unit) expects() once()
+//    (rawKafkaConsumer.close _ : () => Unit) expects() once()
+//    KafkaConsumer.cleanupConsumer[IO, String, String](kafkaConsumer).unsafeRunSync()
+//  }
+//
+//  "poll" should "call consumer.poll with supplied duration" in {
+//    forAll { (d: FiniteDuration) =>
+//      (rawKafkaConsumer.poll _) expects(d.toMillis) returns
+//        (new ApacheConsumerRecords[String,String](Map.empty[org.apache.kafka.common.TopicPartition, java.util.List[ApacheConsumerRecord[String, String]]].asJava)) once()
+//      KafkaConsumer.pollKafka[IO, String, String](kafkaConsumer)(d).unsafeRunSync()
+//    }
+//  }
+//
+//  "commit offset map" should "call consumer.commitAsync with the supplied OffsetMap" in {
+//    forAll { (offsetMap : Map[TopicPartition, OffsetMetadata]) =>
+//      val javaMap = offsetMap.toKafkaSdk
+//
+//      (rawKafkaConsumer.commitAsync(_ : java.util.Map[org.apache.kafka.common.TopicPartition,  org.apache.kafka.clients.consumer.OffsetAndMetadata], _ : OffsetCommitCallback))
+//        .expects (javaMap, *) onCall { (_, callback) => callback.onComplete(javaMap, null) } once()
+//
+//      val errorSignal = async.signalOf[IO, Boolean](false).unsafeRunSync()
+//
+//      (KafkaConsumer.commitOffsetMap[IO, String, String](kafkaConsumer)(offsetMap)(errorSignal) *> IO{Thread.sleep(500)}).unsafeRunSync()
+//    }
+//  }
+//
+//  "commit offset map" should "trigger the error signal if an error was received from the callback" in {
+//    forAll { (offsetMap : Map[TopicPartition, OffsetMetadata]) =>
+//      val javaMap = offsetMap.toKafkaSdk
+//
+//      (rawKafkaConsumer.commitAsync(_ : java.util.Map[org.apache.kafka.common.TopicPartition,  org.apache.kafka.clients.consumer.OffsetAndMetadata], _ : OffsetCommitCallback))
+//        .expects (javaMap, *) onCall { (_, callback) => callback.onComplete(javaMap, new Exception("Red alert!")) } once()
+//
+//      val errorSignal = async.signalOf[IO, Boolean](false).unsafeRunSync()
+//
+//      KafkaConsumer.commitOffsetMap[IO, String, String](kafkaConsumer)(offsetMap)(errorSignal).unsafeRunSync()
+//
+//      val signalTrue = errorSignal.discrete.dropWhile(!_).head.compile.toList.unsafeRunSync().head
+//
+//      signalTrue shouldBe true
+//    }
+//  }
+//
+//  "accumulate offset metadata" should "return the largest offsets for each topic/partition" in {
+//    forAll { consumerRecords: List[consumer.ConsumerRecord[String, String]] =>
+//      val finalMap: Map[TopicPartition, OffsetMetadata] = Stream.emits(consumerRecords)
+//          .through(KafkaConsumer.accumulateOffsetMetadata)
+//          .map{case (_, offsets) => offsets}
+//          .toVector
+//          .last
+//
+//      val expectedMap: Map[TopicPartition, OffsetMetadata] =
+//        consumerRecords.groupBy(_.topicPartition)
+//          .map{ case (k, v) => k -> OffsetMetadata(v.map(_.offset).max) }
+//
+//      finalMap shouldBe expectedMap
+//    }
+//  }
+//
+//  "deserializer" should "call deserialize on the key and value deserializers with the supplied stream values" in {
+//    forAll { consumerRecords: List[consumer.ConsumerRecord[Array[Byte], Array[Byte]]] =>
+//      val intDeserializer = mock[Deserializer[Array[Int]]]
+//
+//      (intDeserializer.deserialize (_ : String, _ : Array[Byte])) expects(*, *) onCall((_, arr) => TestHelpers.byteArrayToIntArray(arr)) atLeastOnce()
+//
+//      val (ks, vs) =
+//        Stream.emits(consumerRecords)
+//          .covary[IO]
+//          .through(KafkaConsumer.deserializer[IO, Array[Int], Array[Int]](intDeserializer, intDeserializer))
+//          .collect { case Right(r) => r }
+//          .compile
+//          .toList
+//          .unsafeRunSync()
+//          .map(r => (r.key, r.value))
+//          .unzip
+//
+//      val expectedKeys: List[Array[Int]] = consumerRecords.map(c => TestHelpers.byteArrayToIntArray(c.key))
+//      val expectedVals: List[Array[Int]] = consumerRecords.map(c => TestHelpers.byteArrayToIntArray(c.value))
+//
+//      ks should contain theSameElementsAs expectedKeys
+//      vs should contain theSameElementsAs expectedVals
+//    }
+//  }
+//
+//
+//}

--- a/src/test/scala/org/novelfs/streaming/kafka/KafkaConsumerSpec.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/KafkaConsumerSpec.scala
@@ -1,109 +1,115 @@
-//package org.novelfs.streaming.kafka
-//
-//import cats.implicits._
-//import cats.effect._
-//import org.scalamock.scalatest.MockFactory
-//import org.scalatest.{FlatSpec, Matchers}
-//import org.apache.kafka.clients.consumer.{ConsumerRecord => ApacheConsumerRecord, ConsumerRecords => ApacheConsumerRecords, OffsetCommitCallback, Consumer => ApacheKafkaConsumer}
-//import org.scalatest.prop.GeneratorDrivenPropertyChecks
-//
-//import scala.concurrent.duration._
-//import collection.JavaConverters._
-//import fs2._
-//import org.apache.kafka.common.serialization.Deserializer
-//import KafkaSdkConversions._
-//import org.novelfs.streaming.kafka.consumer.{KafkaConsumer, OffsetMetadata}
-//import scala.concurrent.ExecutionContext.Implicits.global
-//
-//class KafkaConsumerSpec extends FlatSpec with Matchers with MockFactory with GeneratorDrivenPropertyChecks with DomainArbitraries {
-//
-//  val rawKafkaConsumer = mock[ApacheKafkaConsumer[String, String]]
-//  val kafkaConsumer = KafkaConsumer(rawKafkaConsumer)
-//
-//  "cleanupConsumer" should "call consumer.wakeup() and consumer.close()" in {
-//    (rawKafkaConsumer.wakeup _ : () => Unit) expects() once()
-//    (rawKafkaConsumer.close _ : () => Unit) expects() once()
-//    KafkaConsumer.cleanupConsumer[IO, String, String](kafkaConsumer).unsafeRunSync()
-//  }
-//
-//  "poll" should "call consumer.poll with supplied duration" in {
-//    forAll { (d: FiniteDuration) =>
-//      (rawKafkaConsumer.poll _) expects(d.toMillis) returns
-//        (new ApacheConsumerRecords[String,String](Map.empty[org.apache.kafka.common.TopicPartition, java.util.List[ApacheConsumerRecord[String, String]]].asJava)) once()
-//      KafkaConsumer.pollKafka[IO, String, String](kafkaConsumer)(d).unsafeRunSync()
-//    }
-//  }
-//
-//  "commit offset map" should "call consumer.commitAsync with the supplied OffsetMap" in {
-//    forAll { (offsetMap : Map[TopicPartition, OffsetMetadata]) =>
-//      val javaMap = offsetMap.toKafkaSdk
-//
-//      (rawKafkaConsumer.commitAsync(_ : java.util.Map[org.apache.kafka.common.TopicPartition,  org.apache.kafka.clients.consumer.OffsetAndMetadata], _ : OffsetCommitCallback))
-//        .expects (javaMap, *) onCall { (_, callback) => callback.onComplete(javaMap, null) } once()
-//
-//      val errorSignal = async.signalOf[IO, Boolean](false).unsafeRunSync()
-//
-//      (KafkaConsumer.commitOffsetMap[IO, String, String](kafkaConsumer)(offsetMap)(errorSignal) *> IO{Thread.sleep(500)}).unsafeRunSync()
-//    }
-//  }
-//
-//  "commit offset map" should "trigger the error signal if an error was received from the callback" in {
-//    forAll { (offsetMap : Map[TopicPartition, OffsetMetadata]) =>
-//      val javaMap = offsetMap.toKafkaSdk
-//
-//      (rawKafkaConsumer.commitAsync(_ : java.util.Map[org.apache.kafka.common.TopicPartition,  org.apache.kafka.clients.consumer.OffsetAndMetadata], _ : OffsetCommitCallback))
-//        .expects (javaMap, *) onCall { (_, callback) => callback.onComplete(javaMap, new Exception("Red alert!")) } once()
-//
-//      val errorSignal = async.signalOf[IO, Boolean](false).unsafeRunSync()
-//
-//      KafkaConsumer.commitOffsetMap[IO, String, String](kafkaConsumer)(offsetMap)(errorSignal).unsafeRunSync()
-//
-//      val signalTrue = errorSignal.discrete.dropWhile(!_).head.compile.toList.unsafeRunSync().head
-//
-//      signalTrue shouldBe true
-//    }
-//  }
-//
-//  "accumulate offset metadata" should "return the largest offsets for each topic/partition" in {
-//    forAll { consumerRecords: List[consumer.ConsumerRecord[String, String]] =>
-//      val finalMap: Map[TopicPartition, OffsetMetadata] = Stream.emits(consumerRecords)
-//          .through(KafkaConsumer.accumulateOffsetMetadata)
-//          .map{case (_, offsets) => offsets}
-//          .toVector
-//          .last
-//
-//      val expectedMap: Map[TopicPartition, OffsetMetadata] =
-//        consumerRecords.groupBy(_.topicPartition)
-//          .map{ case (k, v) => k -> OffsetMetadata(v.map(_.offset).max) }
-//
-//      finalMap shouldBe expectedMap
-//    }
-//  }
-//
-//  "deserializer" should "call deserialize on the key and value deserializers with the supplied stream values" in {
-//    forAll { consumerRecords: List[consumer.ConsumerRecord[Array[Byte], Array[Byte]]] =>
-//      val intDeserializer = mock[Deserializer[Array[Int]]]
-//
-//      (intDeserializer.deserialize (_ : String, _ : Array[Byte])) expects(*, *) onCall((_, arr) => TestHelpers.byteArrayToIntArray(arr)) atLeastOnce()
-//
-//      val (ks, vs) =
-//        Stream.emits(consumerRecords)
-//          .covary[IO]
-//          .through(KafkaConsumer.deserializer[IO, Array[Int], Array[Int]](intDeserializer, intDeserializer))
-//          .collect { case Right(r) => r }
-//          .compile
-//          .toList
-//          .unsafeRunSync()
-//          .map(r => (r.key, r.value))
-//          .unzip
-//
-//      val expectedKeys: List[Array[Int]] = consumerRecords.map(c => TestHelpers.byteArrayToIntArray(c.key))
-//      val expectedVals: List[Array[Int]] = consumerRecords.map(c => TestHelpers.byteArrayToIntArray(c.value))
-//
-//      ks should contain theSameElementsAs expectedKeys
-//      vs should contain theSameElementsAs expectedVals
-//    }
-//  }
-//
-//
-//}
+package org.novelfs.streaming.kafka
+
+import cats.implicits._
+import cats.effect._
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{FlatSpec, Matchers}
+import org.apache.kafka.clients.consumer.{Consumer => ApacheKafkaConsumer, ConsumerRecord => ApacheConsumerRecord, ConsumerRecords => ApacheConsumerRecords}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import scala.concurrent.duration._
+import collection.JavaConverters._
+import fs2._
+import org.apache.kafka.common.serialization.Deserializer
+import KafkaSdkConversions._
+import cats.effect.concurrent.MVar
+import org.novelfs.streaming.kafka.consumer.{KafkaConsumer, OffsetMetadata}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class KafkaConsumerSpec extends FlatSpec with Matchers with MockFactory with GeneratorDrivenPropertyChecks with DomainArbitraries {
+
+  trait KafkaConsumerSpecContext {
+    val rawKafkaConsumer = mock[ApacheKafkaConsumer[String, String]]
+    val kafkaConsumer = MVar.of[IO, KafkaConsumer[String, String]](KafkaConsumer(rawKafkaConsumer)).unsafeRunSync()
+  }
+
+  "cleanupConsumer" should "call consumer.wakeup() and consumer.close()" in new KafkaConsumerSpecContext {
+    (rawKafkaConsumer.wakeup _ : () => Unit) expects() once()
+    (rawKafkaConsumer.close _ : () => Unit) expects() once()
+
+    KafkaConsumer.cleanupConsumer[IO, String, String](kafkaConsumer).unsafeRunSync()
+  }
+
+  "poll" should "call consumer.poll with supplied duration" in new KafkaConsumerSpecContext {
+    forAll { (d: FiniteDuration) =>
+      (rawKafkaConsumer.poll _) expects(d.toMillis) returns
+        (new ApacheConsumerRecords[String,String](Map.empty[org.apache.kafka.common.TopicPartition, java.util.List[ApacheConsumerRecord[String, String]]].asJava)) once()
+      KafkaConsumer.pollKafka[IO, String, String](kafkaConsumer)(d).unsafeRunSync()
+    }
+  }
+
+  "commit offset map" should "call consumer.commitSync with the supplied OffsetMap" in new KafkaConsumerSpecContext {
+    forAll { (offsetMap : Map[TopicPartition, OffsetMetadata]) =>
+      val javaMap = offsetMap.toKafkaSdk
+
+      (rawKafkaConsumer.commitSync(_ : java.util.Map[org.apache.kafka.common.TopicPartition,  org.apache.kafka.clients.consumer.OffsetAndMetadata]))
+        .expects (javaMap) once()
+
+      val errorSignal = async.signalOf[IO, Boolean](false).unsafeRunSync()
+
+      (KafkaConsumer.commitOffsetMap[IO, String, String](kafkaConsumer)(offsetMap)(errorSignal) *> IO{Thread.sleep(500)}).unsafeRunSync()
+    }
+  }
+
+  "commit offset map" should "trigger the error signal if an error was received from the callback" in new KafkaConsumerSpecContext {
+    forAll { (offsetMap : Map[TopicPartition, OffsetMetadata]) =>
+      val javaMap = offsetMap.toKafkaSdk
+
+      (rawKafkaConsumer.commitSync(_ : java.util.Map[org.apache.kafka.common.TopicPartition,  org.apache.kafka.clients.consumer.OffsetAndMetadata]))
+        .expects (javaMap) onCall { _ => throw new RuntimeException("Argh") } once()
+
+      val errorSignal = async.signalOf[IO, Boolean](false).unsafeRunSync()
+
+      KafkaConsumer.commitOffsetMap[IO, String, String](kafkaConsumer)(offsetMap)(errorSignal).unsafeRunSync()
+
+      val signalTrue = errorSignal.discrete.dropWhile(!_).head.compile.toList.unsafeRunSync().head
+
+      signalTrue shouldBe true
+    }
+  }
+
+  "accumulate offset metadata" should "return the largest offsets for each topic/partition" in new KafkaConsumerSpecContext {
+    forAll { consumerRecords: List[consumer.ConsumerRecord[String, String]] =>
+      val finalMap: Map[TopicPartition, OffsetMetadata] = Stream.emits(consumerRecords)
+          .covary[IO]
+          .through(KafkaConsumer.accumulateOffsetMetadata)
+          .map{case (_, offsets) => offsets}
+          .compile
+          .toVector
+          .unsafeRunSync()
+          .last
+
+      val expectedMap: Map[TopicPartition, OffsetMetadata] =
+        consumerRecords.groupBy(_.topicPartition)
+          .map{ case (k, v) => k -> OffsetMetadata(v.map(_.offset).max) }
+
+      finalMap shouldBe expectedMap
+    }
+  }
+
+  "deserializer" should "call deserialize on the key and value deserializers with the supplied stream values" in new KafkaConsumerSpecContext {
+    forAll { consumerRecords: List[consumer.ConsumerRecord[Array[Byte], Array[Byte]]] =>
+      val intDeserializer = mock[Deserializer[Array[Int]]]
+
+      (intDeserializer.deserialize (_ : String, _ : Array[Byte])) expects(*, *) onCall((_, arr) => TestHelpers.byteArrayToIntArray(arr)) atLeastOnce()
+
+      val (ks, vs) =
+        Stream.emits(consumerRecords)
+          .covary[IO]
+          .through(KafkaConsumer.deserializer[IO, Array[Int], Array[Int]](intDeserializer, intDeserializer))
+          .collect { case Right(r) => r }
+          .compile
+          .toList
+          .unsafeRunSync()
+          .map(r => (r.key, r.value))
+          .unzip
+
+      val expectedKeys: List[Array[Int]] = consumerRecords.map(c => TestHelpers.byteArrayToIntArray(c.key))
+      val expectedVals: List[Array[Int]] = consumerRecords.map(c => TestHelpers.byteArrayToIntArray(c.value))
+
+      ks should contain theSameElementsAs expectedKeys
+      vs should contain theSameElementsAs expectedVals
+    }
+  }
+
+
+}

--- a/src/test/scala/org/novelfs/streaming/kafka/KafkaConsumerSpec.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/KafkaConsumerSpec.scala
@@ -21,13 +21,6 @@ class KafkaConsumerSpec extends FlatSpec with Matchers with MockFactory with Gen
     val kafkaConsumer = MVar.of[IO, KafkaConsumer[String, String]](KafkaConsumer(rawKafkaConsumer)).unsafeRunSync()
   }
 
-  "cleanupConsumer" should "call consumer.wakeup() and consumer.close()" in new KafkaConsumerSpecContext {
-    (rawKafkaConsumer.wakeup _ : () => Unit) expects() once()
-    (rawKafkaConsumer.close _ : () => Unit) expects() once()
-
-    KafkaConsumerSubscription.cleanup[IO, String, String](kafkaSubscription).unsafeRunSync()
-  }
-
   "accumulate offset metadata" should "return the largest offsets for each topic/partition" in new KafkaConsumerSpecContext {
     forAll { consumerRecords: List[consumer.ConsumerRecord[String, String]] =>
       val finalMap: Map[TopicPartition, OffsetMetadata] = Stream.emits(consumerRecords)

--- a/src/test/scala/org/novelfs/streaming/kafka/KafkaConsumerSpec.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/KafkaConsumerSpec.scala
@@ -8,7 +8,6 @@ import org.apache.kafka.clients.consumer.{Consumer => ApacheKafkaConsumer}
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import fs2._
 import org.apache.kafka.common.serialization.Deserializer
-import cats.effect.concurrent.MVar
 import org.novelfs.streaming.kafka.consumer.{KafkaConsumer, KafkaConsumerSubscription, OffsetMetadata}
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -18,7 +17,6 @@ class KafkaConsumerSpec extends FlatSpec with Matchers with MockFactory with Gen
   trait KafkaConsumerSpecContext {
     val rawKafkaConsumer = mock[ApacheKafkaConsumer[String, String]]
     val kafkaSubscription = KafkaConsumerSubscription(rawKafkaConsumer)
-    val kafkaConsumer = MVar.of[IO, KafkaConsumer[String, String]](KafkaConsumer(rawKafkaConsumer)).unsafeRunSync()
   }
 
   "accumulate offset metadata" should "return the largest offsets for each topic/partition" in new KafkaConsumerSpecContext {

--- a/src/test/scala/org/novelfs/streaming/kafka/KafkaConsumerSubscriptionSpec.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/KafkaConsumerSubscriptionSpec.scala
@@ -1,0 +1,24 @@
+package org.novelfs.streaming.kafka
+
+import cats.effect.IO
+import org.novelfs.streaming.kafka.consumer.KafkaConsumerSubscription
+import org.apache.kafka.clients.consumer.{Consumer => ApacheKafkaConsumer}
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+
+class KafkaConsumerSubscriptionSpec extends FlatSpec with Matchers with MockFactory with GeneratorDrivenPropertyChecks with DomainArbitraries  {
+
+  trait KafkaConsumerSubscriptionSpecContext {
+    val rawKafkaConsumer = mock[ApacheKafkaConsumer[String, String]]
+    val kafkaSubscription = KafkaConsumerSubscription(rawKafkaConsumer)
+  }
+
+  "cleanupConsumer" should "call consumer.wakeup() and consumer.close()" in new KafkaConsumerSubscriptionSpecContext {
+    (rawKafkaConsumer.wakeup _ : () => Unit) expects() once()
+    (rawKafkaConsumer.close _ : () => Unit) expects() once()
+
+    KafkaConsumerSubscription.cleanup[IO, String, String](kafkaSubscription).unsafeRunSync()
+  }
+
+}

--- a/src/test/scala/org/novelfs/streaming/kafka/KafkaProducerIntegrationSpec.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/KafkaProducerIntegrationSpec.scala
@@ -46,6 +46,7 @@ class KafkaProducerIntegrationSpec extends FlatSpec with Matchers with Generator
 
         val consumerStream = KafkaConsumer[IO, String, String](consumerConfig)
         val producerStream = Stream.emits(topicCorrectProducerRecords)
+          .repeat
           .covary[IO]
           .through(KafkaProducer(producerConfig))
 
@@ -56,19 +57,21 @@ class KafkaProducerIntegrationSpec extends FlatSpec with Matchers with Generator
           .collect {
             case Right(r) => r
           }
-          .take(producerRecords.size.toLong)
+          //.take(producerRecords.size.toLong)
           .compile
-          .toList
+          .drain
           .unsafeRunSync()
 
-        val expectedKeys = producerRecords.map(_.key)
-        val expectedVals = producerRecords.map(_.value)
+//        val expectedKeys = producerRecords.map(_.key)
+//        val expectedVals = producerRecords.map(_.value)
+//
+//        val ks = results.map(_.key)
+//        val vs = results.map(_.value)
+//
+//        ks should contain theSameElementsAs expectedKeys
+//        vs should contain theSameElementsAs expectedVals
 
-        val ks = results.map(_.key)
-        val vs = results.map(_.value)
-
-        ks should contain theSameElementsAs expectedKeys
-        vs should contain theSameElementsAs expectedVals
+        results shouldBe (())
       }
     }
   }

--- a/src/test/scala/org/novelfs/streaming/kafka/KafkaProducerIntegrationSpec.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/KafkaProducerIntegrationSpec.scala
@@ -48,6 +48,7 @@ class KafkaProducerIntegrationSpec extends FlatSpec with Matchers with Generator
         val producerStream = Stream.emits(topicCorrectProducerRecords)
           .repeat
           .covary[IO]
+          //.observe1(_ => IO.sleep(FiniteDuration(4000, "ms")))
           .through(KafkaProducer(producerConfig))
 
         // run the consumer stream and producer stream in parallel and collect up the results into a list

--- a/src/test/scala/org/novelfs/streaming/kafka/KafkaProducerIntegrationSpec.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/KafkaProducerIntegrationSpec.scala
@@ -48,7 +48,6 @@ class KafkaProducerIntegrationSpec extends FlatSpec with Matchers with Generator
         val producerStream = Stream.emits(topicCorrectProducerRecords)
           .repeat
           .covary[IO]
-          //.observe1(_ => IO.sleep(FiniteDuration(4000, "ms")))
           .through(KafkaProducer(producerConfig))
 
         // run the consumer stream and producer stream in parallel and collect up the results into a list
@@ -58,21 +57,19 @@ class KafkaProducerIntegrationSpec extends FlatSpec with Matchers with Generator
           .collect {
             case Right(r) => r
           }
-          //.take(producerRecords.size.toLong)
+          .take(producerRecords.size.toLong)
           .compile
-          .drain
+          .toList
           .unsafeRunSync()
 
-//        val expectedKeys = producerRecords.map(_.key)
-//        val expectedVals = producerRecords.map(_.value)
-//
-//        val ks = results.map(_.key)
-//        val vs = results.map(_.value)
-//
-//        ks should contain theSameElementsAs expectedKeys
-//        vs should contain theSameElementsAs expectedVals
+        val expectedKeys = producerRecords.map(_.key)
+        val expectedVals = producerRecords.map(_.value)
 
-        results shouldBe (())
+        val ks = results.map(_.key)
+        val vs = results.map(_.value)
+
+        ks should contain theSameElementsAs expectedKeys
+        vs should contain theSameElementsAs expectedVals
       }
     }
   }

--- a/src/test/scala/org/novelfs/streaming/kafka/KafkaProducerSpec.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/KafkaProducerSpec.scala
@@ -60,4 +60,5 @@ class KafkaProducerSpec extends FlatSpec with Matchers with MockFactory with Gen
       vs should contain theSameElementsAs expectedVals
     }
   }
+
 }

--- a/src/test/scala/org/novelfs/streaming/kafka/ThinKafkaConsumerClientSpec.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/ThinKafkaConsumerClientSpec.scala
@@ -46,7 +46,7 @@ class ThinKafkaConsumerClientSpec extends FlatSpec with Matchers with MockFactor
 
       val result = ThinKafkaConsumerClient[IO].commitOffsetMap(offsetMap)(kafkaSubscription).attempt.unsafeRunSync()
 
-      result.isRight shouldBe true
+      result.isRight shouldBe false
     }
   }
 

--- a/src/test/scala/org/novelfs/streaming/kafka/ThinKafkaConsumerClientSpec.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/ThinKafkaConsumerClientSpec.scala
@@ -48,7 +48,7 @@ class ThinKafkaConsumerClientSpec extends FlatSpec with Matchers with MockFactor
     }
   }
 
-  "zube" should "zuuube" in new ThinKafkaConsumerClientSpecContext {
+  "topicPartitionAssignments" should "call consumer.assignment" in new ThinKafkaConsumerClientSpecContext {
     ((rawKafkaConsumer.assignment _) : () => java.util.Set[org.apache.kafka.common.TopicPartition]).expects().returns(new java.util.HashSet[org.apache.kafka.common.TopicPartition]())
 
     ThinKafkaConsumerClient[IO].topicPartitionAssignments(kafkaSubscription).unsafeRunSync()

--- a/src/test/scala/org/novelfs/streaming/kafka/ThinKafkaConsumerClientSpec.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/ThinKafkaConsumerClientSpec.scala
@@ -44,7 +44,9 @@ class ThinKafkaConsumerClientSpec extends FlatSpec with Matchers with MockFactor
       (rawKafkaConsumer.commitSync(_ : java.util.Map[org.apache.kafka.common.TopicPartition,  org.apache.kafka.clients.consumer.OffsetAndMetadata]))
         .expects (javaMap) onCall { _ => throw new RuntimeException("Argh") } once()
 
-      ThinKafkaConsumerClient[IO].commitOffsetMap(offsetMap)(kafkaSubscription).unsafeRunSync()
+      val result = ThinKafkaConsumerClient[IO].commitOffsetMap(offsetMap)(kafkaSubscription).attempt.unsafeRunSync()
+
+      result.isRight shouldBe true
     }
   }
 

--- a/src/test/scala/org/novelfs/streaming/kafka/ThinKafkaConsumerClientSpec.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/ThinKafkaConsumerClientSpec.scala
@@ -22,7 +22,7 @@ class ThinKafkaConsumerClientSpec extends FlatSpec with Matchers with MockFactor
       (rawKafkaConsumer.poll _) expects(d.toMillis) returns
         (new ApacheConsumerRecords[String,String](Map.empty[org.apache.kafka.common.TopicPartition, java.util.List[ApacheConsumerRecord[String, String]]].asJava)) once()
 
-      ThinKafkaConsumerClient[IO].poll(d)(kafkaSubscription)
+      ThinKafkaConsumerClient[IO].poll(d)(kafkaSubscription).unsafeRunSync()
     }
   }
 

--- a/src/test/scala/org/novelfs/streaming/kafka/ThinKafkaConsumerClientSpec.scala
+++ b/src/test/scala/org/novelfs/streaming/kafka/ThinKafkaConsumerClientSpec.scala
@@ -1,0 +1,56 @@
+package org.novelfs.streaming.kafka
+
+import cats.effect.IO
+import org.novelfs.streaming.kafka.consumer.{KafkaConsumerSubscription, OffsetMetadata}
+import org.novelfs.streaming.kafka.KafkaSdkConversions._
+import org.apache.kafka.clients.consumer.{Consumer => ApacheKafkaConsumer, ConsumerRecord => ApacheConsumerRecord, ConsumerRecords => ApacheConsumerRecords}
+import org.novelfs.streaming.kafka.interpreter.ThinKafkaConsumerClient
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import scala.concurrent.duration.FiniteDuration
+import scala.collection.JavaConverters._
+
+class ThinKafkaConsumerClientSpec extends FlatSpec with Matchers with MockFactory with GeneratorDrivenPropertyChecks with DomainArbitraries {
+  trait ThinKafkaConsumerClientSpecContext {
+    val rawKafkaConsumer = mock[ApacheKafkaConsumer[String, String]]
+    val kafkaSubscription = KafkaConsumerSubscription(rawKafkaConsumer)
+  }
+
+  "poll" should "call consumer.poll with supplied duration" in new ThinKafkaConsumerClientSpecContext {
+    forAll { (d: FiniteDuration) =>
+      (rawKafkaConsumer.poll _) expects(d.toMillis) returns
+        (new ApacheConsumerRecords[String,String](Map.empty[org.apache.kafka.common.TopicPartition, java.util.List[ApacheConsumerRecord[String, String]]].asJava)) once()
+
+      ThinKafkaConsumerClient[IO].poll(d)(kafkaSubscription)
+    }
+  }
+
+  "commit offset map" should "call consumer.commitSync with the supplied OffsetMap" in new ThinKafkaConsumerClientSpecContext {
+    forAll { (offsetMap : Map[TopicPartition, OffsetMetadata]) =>
+      val javaMap = offsetMap.toKafkaSdk
+
+      (rawKafkaConsumer.commitSync(_ : java.util.Map[org.apache.kafka.common.TopicPartition,  org.apache.kafka.clients.consumer.OffsetAndMetadata]))
+        .expects (javaMap) once()
+
+      ThinKafkaConsumerClient[IO].commitOffsetMap(offsetMap)(kafkaSubscription).unsafeRunSync()
+    }
+  }
+
+  "commit offset map" should "fail if an error was received from the callback" in new ThinKafkaConsumerClientSpecContext {
+    forAll { (offsetMap : Map[TopicPartition, OffsetMetadata]) =>
+      val javaMap = offsetMap.toKafkaSdk
+
+      (rawKafkaConsumer.commitSync(_ : java.util.Map[org.apache.kafka.common.TopicPartition,  org.apache.kafka.clients.consumer.OffsetAndMetadata]))
+        .expects (javaMap) onCall { _ => throw new RuntimeException("Argh") } once()
+
+      ThinKafkaConsumerClient[IO].commitOffsetMap(offsetMap)(kafkaSubscription).unsafeRunSync()
+    }
+  }
+
+  "zube" should "zuuube" in new ThinKafkaConsumerClientSpecContext {
+    ((rawKafkaConsumer.assignment _) : () => java.util.Set[org.apache.kafka.common.TopicPartition]).expects().returns(new java.util.HashSet[org.apache.kafka.common.TopicPartition]())
+
+    ThinKafkaConsumerClient[IO].topicPartitionAssignments(kafkaSubscription).unsafeRunSync()
+  }
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.7"
+version in ThisBuild := "0.4.0"


### PR DESCRIPTION
- Locked access to the consumer so that multiple threads can make use of it
- Restored the multi-threaded commit system
- Refactored the consumer to use a new subscription-based system
- Added algebra for direct consumption
